### PR TITLE
Correct extension directives placement

### DIFF
--- a/src/sksl/SkSLGLSLCodeGenerator.cpp
+++ b/src/sksl/SkSLGLSLCodeGenerator.cpp
@@ -1229,25 +1229,6 @@ void GLSLCodeGenerator::writeHeader() {
             this->writeExtension((Extension&) *e);
         }
     }
-    if (!fProgram.fSettings.fCaps->canUseFragCoord()) {
-        Layout layout;
-        switch (fProgram.fKind) {
-            case Program::kVertex_Kind: {
-                Modifiers modifiers(layout, Modifiers::kOut_Flag | Modifiers::kHighp_Flag);
-                this->writeModifiers(modifiers, true);
-                this->write("vec4 sk_FragCoord_Workaround;\n");
-                break;
-            }
-            case Program::kFragment_Kind: {
-                Modifiers modifiers(layout, Modifiers::kIn_Flag | Modifiers::kHighp_Flag);
-                this->writeModifiers(modifiers, true);
-                this->write("vec4 sk_FragCoord_Workaround;\n");
-                break;
-            }
-            default:
-                break;
-        }
-    }
 }
 
 void GLSLCodeGenerator::writeProgramElement(const ProgramElement& e) {
@@ -1324,6 +1305,27 @@ bool GLSLCodeGenerator::generateCode() {
     fOut = rawOut;
 
     write_stringstream(fHeader, *rawOut);
+
+    if (!fProgram.fSettings.fCaps->canUseFragCoord()) {
+        Layout layout;
+        switch (fProgram.fKind) {
+            case Program::kVertex_Kind: {
+                Modifiers modifiers(layout, Modifiers::kOut_Flag | Modifiers::kHighp_Flag);
+                this->writeModifiers(modifiers, true);
+                this->write("vec4 sk_FragCoord_Workaround;\n");
+                break;
+            }
+            case Program::kFragment_Kind: {
+                Modifiers modifiers(layout, Modifiers::kIn_Flag | Modifiers::kHighp_Flag);
+                this->writeModifiers(modifiers, true);
+                this->write("vec4 sk_FragCoord_Workaround;\n");
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
     if (this->usesPrecisionModifiers()) {
         this->writeLine("precision mediump float;");
     }


### PR DESCRIPTION
Extension directives must occur before any non-preprocessor tokens.
this will solve shader compilation errors from below generated shader

7-17 03:56:00.100 12331 12609 D skia    : GLSL:
07-17 03:56:00.100 12331 12609 D skia    :    1 #version 100
07-17 03:56:00.100 12331 12609 D skia    :    2
07-17 03:56:00.100 12331 12609 D skia    :    3 varying highp vec4 sk_FragCoord_Workaround;
07-17 03:56:00.100 12331 12609 D skia    :    4 #extension GL_OES_standard_derivatives : require
07-17 03:56:00.100 12331 12609 D skia    :    5 precision mediump float;
07-17 03:56:00.100 12331 12609 D skia    :    6 varying mediump vec4 vQuadEdge_Stage0;
07-17 03:56:00.100 12331 12609 D skia    :    7 varying mediump vec4 vinColor_Stage0;
07-17 03:56:00.100 12331 12609 D skia    :    8 void main() {
07-17 03:56:00.100 12331 12609 D skia    :    9     mediump vec4 outputColor_Stage0;
07-17 03:56:00.100 12331 12609 D skia    :   10     mediump vec4 outputCoverage_Stage0;
07-17 03:56:00.100 12331 12609 D skia    :   11     {
: