### PR TITLE
Fix the spelling of ProcSet.

### DIFF
--- a/src/pdf/SkPDFDocument.cpp
+++ b/src/pdf/SkPDFDocument.cpp
@@ -444,7 +444,7 @@ static sk_sp<SkPDFDict> make_top_resource_dict() {
     for (const char* proc : kProcs) {
         procSet->appendName(proc);
     }
-    dict->insertObject("ProcSets", std::move(procSet));
+    dict->insertObject("ProcSet", std::move(procSet));
     return dict;
 }
 


### PR DESCRIPTION
PDFs generated by Chrome currently generate warnings when included in
LaTeX documents. pdflatex prints warnings along the lines of:

    PDF inclusion: invalid other resource which is no dict
        (key 'ProcSets', type <array>); ignored

Taking a look at PDFs generated by other tools, this field is supposed
to be called ProcSet, without a trailing s.

CC @HalCanary 