### PR TITLE
[gn] python3 compatible

### DIFF
--- a/bin/fetch-gn
+++ b/bin/fetch-gn
@@ -10,7 +10,6 @@ import os
 import shutil
 import stat
 import sys
-import urllib2
 
 os.chdir(os.path.join(os.path.dirname(__file__), os.pardir))
 
@@ -27,10 +26,19 @@ def sha1_of_file(path):
       h.update(f.read())
   return h.hexdigest()
 
-if sha1_of_file(dst) != sha1:
-  with open(dst, 'wb') as f:
-    f.write(urllib2.urlopen('https://chromium-gn.storage-download.googleapis.com/' + sha1).read())
+def download_file(url, local_path):
+  major = sys.version_info[0]
+  if major == 2:
+    import urllib2
+    with open(local_path, 'wb') as f:
+      f.write(urllib2.urlopen(url).read())
+  elif major == 3:
+    from urllib import request
+    with open(local_path, 'wb') as f:
+      f.write(request.urlopen(url).read())
 
+if sha1_of_file(dst) != sha1:
+  download_file('https://chromium-gn.storage-download.googleapis.com/' + sha1, dst)
   os.chmod(dst, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
                 stat.S_IRGRP                | stat.S_IXGRP |
                 stat.S_IROTH                | stat.S_IXOTH )

--- a/gn/checkdir.py
+++ b/gn/checkdir.py
@@ -10,6 +10,6 @@ import sys
 
 dirpath, = sys.argv[1:]
 
-print os.path.isdir(dirpath)
+print(os.path.isdir(dirpath))
 
 

--- a/gn/find_headers.py
+++ b/gn/find_headers.py
@@ -34,14 +34,14 @@ desc_json_txt = ''
 try:
   desc_json_txt = subprocess.check_output(gn_desc_cmd)
 except subprocess.CalledProcessError as e:
-  print e.output
+  print(e.output)
   raise
 
 desc_json = {}
 try:
   desc_json = json.loads(desc_json_txt)
 except ValueError:
-  print desc_json_txt
+  print(desc_json_txt)
   raise
 
 sources = set()

--- a/gn/find_ios_sysroot.py
+++ b/gn/find_ios_sysroot.py
@@ -10,4 +10,4 @@ import sys
 
 (sdk,) = sys.argv[1:]
 
-print subprocess.check_output(['xcrun', '--sdk', sdk, '--show-sdk-path'])
+print(subprocess.check_output(['xcrun', '--sdk', sdk, '--show-sdk-path']))

--- a/gn/highest_version_dir.py
+++ b/gn/highest_version_dir.py
@@ -12,4 +12,4 @@ import sys
 dirpath = sys.argv[1]
 regex = re.compile(sys.argv[2])
 
-print sorted(filter(regex.match, os.listdir(dirpath)))[-1]
+print(sorted(filter(regex.match, os.listdir(dirpath)))[-1])

--- a/tools/git-sync-deps
+++ b/tools/git-sync-deps
@@ -94,6 +94,8 @@ def is_git_toplevel(git, directory):
   try:
     toplevel = subprocess.check_output(
       [git, 'rev-parse', '--show-toplevel'], cwd=directory).strip()
+    if sys.version_info[0] == 3:
+      toplevel = toplevel.decode(encoding='utf-8', errors='strict')
     return os.path.realpath(directory) == os.path.realpath(toplevel)
   except subprocess.CalledProcessError:
     return False
@@ -167,7 +169,12 @@ def git_checkout_to_directory(git, repo, checkoutable, directory, verbose):
 
 def parse_file_to_dict(path):
   dictionary = {}
-  execfile(path, dictionary)
+  if sys.version_info[0] == 2:
+    execfile(path, dictionary)
+  else:
+    with open(path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    exec(content, {}, dictionary)
   return dictionary
 
 
@@ -204,9 +211,9 @@ def git_sync_deps(deps_file_path, command_line_os_requests, verbose):
         raise Exception('%r is parent of %r' % (other_dir, directory))
   list_of_arg_lists = []
   for directory in sorted(dependencies):
-    if not isinstance(dependencies[directory], basestring):
+    if not isinstance(dependencies[directory], str):
       if verbose:
-        print 'Skipping "%s".' % directory
+        print('Skipping "%s".' % directory)
       continue
     if '@' in dependencies[directory]:
       repo, checkoutable = dependencies[directory].split('@', 1)


### PR DESCRIPTION
  * git-sync-deps also resolved
users can using either python2.7 or python3.x now. after clone, users can run: python3 tools/git-sync-deps, then run gn & ninja for a skia library