### PR TITLE
SkottieProperty: Report node traversal to allow keypath composition.

### DIFF
--- a/modules/skottie/include/SkottieProperty.h
+++ b/modules/skottie/include/SkottieProperty.h
@@ -119,6 +119,8 @@ public:
                                      const LazyHandle<TextPropertyHandle>&);
     virtual void onTransformProperty(const char node_name[],
                                      const LazyHandle<TransformPropertyHandle>&);
+    virtual void onEnterNode(const char node_name[]);
+    virtual void onLeavingProperty(const char node_name[]);
 };
 
 } // namespace skottie

--- a/modules/skottie/src/Skottie.cpp
+++ b/modules/skottie/src/Skottie.cpp
@@ -291,6 +291,7 @@ void AnimationBuilder::AutoPropertyTracker::updateContext(PropertyObserver* obse
     const skjson::StringValue* name = obj["nm"];
 
     fBuilder->fPropertyObserverContext = name ? name->begin() : nullptr;
+    observer->onEnterNode(fBuilder->fPropertyObserverContext);
 }
 
 } // namespace internal

--- a/modules/skottie/src/SkottiePriv.h
+++ b/modules/skottie/src/SkottiePriv.h
@@ -139,6 +139,7 @@ public:
 
         ~AutoPropertyTracker() {
             if (fBuilder->fPropertyObserver) {
+                fBuilder->fPropertyObserver->onLeavingProperty(fBuilder->fPropertyObserverContext);
                 fBuilder->fPropertyObserverContext = fPrevContext;
             }
         }

--- a/modules/skottie/src/SkottieProperty.cpp
+++ b/modules/skottie/src/SkottieProperty.cpp
@@ -124,4 +124,7 @@ void PropertyObserver::onTextProperty(const char[],
 void PropertyObserver::onTransformProperty(const char[],
                                            const LazyHandle<TransformPropertyHandle>&) {}
 
-} // namespace skottie
+void PropertyObserver::onEnterNode(const char node_name[]) {}
+
+void PropertyObserver::onLeavingProperty(const char node_name[]) {}
+}  // namespace skottie

--- a/modules/skottie/utils/SkottieUtils.cpp
+++ b/modules/skottie/utils/SkottieUtils.cpp
@@ -15,26 +15,36 @@ public:
 
     void onColorProperty(const char node_name[],
                          const LazyHandle<skottie::ColorPropertyHandle>& c) override {
-        const auto key = fMgr->acceptKey(node_name);
-        if (!key.empty()) {
-            fMgr->fColorMap[key].push_back(c());
-        }
+        const auto markedKey = fMgr->acceptKey(node_name);
+        const auto key = markedKey.empty() ? markedKey : fMgr->currentNode + ".Color";
+        fMgr->fColorMap[key].push_back(c());
     }
 
     void onOpacityProperty(const char node_name[],
                            const LazyHandle<skottie::OpacityPropertyHandle>& o) override {
-        const auto key = fMgr->acceptKey(node_name);
-        if (!key.empty()) {
-            fMgr->fOpacityMap[key].push_back(o());
-        }
+        const auto markedKey = fMgr->acceptKey(node_name);
+        const auto key = markedKey.empty() ? markedKey : fMgr->currentNode + ".Opacity";
+        fMgr->fOpacityMap[key].push_back(o());
     }
 
     void onTransformProperty(const char node_name[],
                              const LazyHandle<skottie::TransformPropertyHandle>& t) override {
-        const auto key = fMgr->acceptKey(node_name);
-        if (!key.empty()) {
-            fMgr->fTransformMap[key].push_back(t());
-        }
+        const auto markedKey = fMgr->acceptKey(node_name);
+        const auto key = markedKey.empty() ? markedKey : fMgr->currentNode + ".Transform";
+        fMgr->fTransformMap[key].push_back(t());
+    }
+
+    void onEnterNode(const char node_name[]) override {
+        fMgr->currentNode =
+                fMgr->currentNode.empty() ? node_name : fMgr->currentNode + "." + node_name;
+    }
+
+    void onLeavingProperty(const char node_name[]) override {
+        auto length = strlen(node_name);
+        fMgr->currentNode = fMgr->currentNode.length() > length
+                                    ? fMgr->currentNode.substr(
+                                              0, fMgr->currentNode.length() - strlen(node_name) - 1)
+                                    : "";
     }
 
     void onTextProperty(const char node_name[],

--- a/modules/skottie/utils/SkottieUtils.h
+++ b/modules/skottie/utils/SkottieUtils.h
@@ -32,6 +32,7 @@ namespace skottie_utils {
  */
 class CustomPropertyManager final {
 public:
+    std::string currentNode = "";
     CustomPropertyManager();
     ~CustomPropertyManager();
 


### PR DESCRIPTION
This change allows users of PropertyObserver to compose a full keypath for each of the modified properties.
Also this contains a demonstration of how to implement this in CustomPropertyManager.