### PR TITLE
GrGLPath: Fix hitting an assert when a style applies a path effect that results in an empty path

### DIFF
--- a/gm/dashing.cpp
+++ b/gm/dashing.cpp
@@ -600,6 +600,29 @@ DEF_SIMPLE_GM(thin_aa_dash_lines, canvas, 330, 110) {
     }
 }
 
+DEF_SIMPLE_GM(path_effect_empty_result, canvas, 100, 100)
+{
+	SkPaint p;
+	p.setStroke(true);
+	p.setStrokeWidth(1);
+
+	SkPath path;
+	float r = 70;
+	float l = 70;
+	float t = 70;
+	float b = 70;
+	path.moveTo(l, t);
+	path.lineTo(r, t);
+	path.lineTo(r, b);
+	path.lineTo(l, b);
+	path.close();
+
+	float dashes[] = { 2.f, 2.f };
+	p.setPathEffect(SkDashPathEffect::Make(dashes, 2, 0.f));
+
+	canvas->drawPath(path, p);
+}
+
 //////////////////////////////////////////////////////////////////////////////
 
 DEF_GM(return new DashingGM;)

--- a/src/gpu/gl/GrGLPath.cpp
+++ b/src/gpu/gl/GrGLPath.cpp
@@ -286,37 +286,52 @@ GrGLPath::GrGLPath(GrGLGpu* gpu, const SkPath& origSkPath, const GrStyle& style)
             stroke = style.strokeRec();
         }
 
-        bool didInit = false;
-        if (stroke.needToApply() && stroke.getCap() != SkPaint::kButt_Cap) {
-            // Skia stroking and NVPR stroking differ with respect to stroking
-            // end caps of empty subpaths.
-            // Convert stroke to fill if path contains empty subpaths.
-            didInit = InitPathObjectPathDataCheckingDegenerates(gpu, fPathID, *skPath);
-            if (!didInit) {
-                if (!tmpPath.isValid()) {
-                    tmpPath.init();
-                }
-                SkAssertResult(stroke.applyToPath(tmpPath.get(), *skPath));
-                skPath = tmpPath.get();
-                stroke.setFillStyle();
-            }
-        }
+		// applyPathEffectToPath could have generated an empty path
+		if (skPath->isEmpty())
+		{
+			InitPathObjectEmptyPath(gpu, fPathID);
+			fShouldStroke = false;
+			fShouldFill = false;
+		}
+		else
+		{
+			bool didInit = false;
+			if (stroke.needToApply() && stroke.getCap() != SkPaint::kButt_Cap)
+			{
+				// Skia stroking and NVPR stroking differ with respect to stroking
+				// end caps of empty subpaths.
+				// Convert stroke to fill if path contains empty subpaths.
+				didInit = InitPathObjectPathDataCheckingDegenerates(gpu, fPathID, *skPath);
+				if (!didInit)
+				{
+					if (!tmpPath.isValid())
+					{
+						tmpPath.init();
+					}
+					SkAssertResult(stroke.applyToPath(tmpPath.get(), *skPath));
+					skPath = tmpPath.get();
+					stroke.setFillStyle();
+				}
+			}
 
-        if (!didInit) {
-            InitPathObjectPathData(gpu, fPathID, *skPath);
-        }
+			if (!didInit)
+			{
+				InitPathObjectPathData(gpu, fPathID, *skPath);
+			}
 
-        fShouldStroke = stroke.needToApply();
-        fShouldFill = stroke.isFillStyle() ||
-                stroke.getStyle() == SkStrokeRec::kStrokeAndFill_Style;
+			fShouldStroke = stroke.needToApply();
+			fShouldFill = stroke.isFillStyle() ||
+				stroke.getStyle() == SkStrokeRec::kStrokeAndFill_Style;
 
-        fFillType = convert_skpath_filltype(skPath->getFillType());
-        fBounds = skPath->getBounds();
-        SkScalar radius = stroke.getInflationRadius();
-        fBounds.outset(radius, radius);
-        if (fShouldStroke) {
-            InitPathObjectStroke(gpu, fPathID, stroke);
-        }
+			fFillType = convert_skpath_filltype(skPath->getFillType());
+			fBounds = skPath->getBounds();
+			SkScalar radius = stroke.getInflationRadius();
+			fBounds.outset(radius, radius);
+			if (fShouldStroke)
+			{
+				InitPathObjectStroke(gpu, fPathID, stroke);
+			}
+		}
     }
 
     this->registerWithCache(SkBudgeted::kYes);

--- a/src/gpu/gl/GrGLPath.cpp
+++ b/src/gpu/gl/GrGLPath.cpp
@@ -286,52 +286,52 @@ GrGLPath::GrGLPath(GrGLGpu* gpu, const SkPath& origSkPath, const GrStyle& style)
             stroke = style.strokeRec();
         }
 
-		// applyPathEffectToPath could have generated an empty path
-		if (skPath->isEmpty())
-		{
-			InitPathObjectEmptyPath(gpu, fPathID);
-			fShouldStroke = false;
-			fShouldFill = false;
-		}
-		else
-		{
-			bool didInit = false;
-			if (stroke.needToApply() && stroke.getCap() != SkPaint::kButt_Cap)
-			{
-				// Skia stroking and NVPR stroking differ with respect to stroking
-				// end caps of empty subpaths.
-				// Convert stroke to fill if path contains empty subpaths.
-				didInit = InitPathObjectPathDataCheckingDegenerates(gpu, fPathID, *skPath);
-				if (!didInit)
-				{
-					if (!tmpPath.isValid())
-					{
-						tmpPath.init();
-					}
-					SkAssertResult(stroke.applyToPath(tmpPath.get(), *skPath));
-					skPath = tmpPath.get();
-					stroke.setFillStyle();
-				}
-			}
+        // applyPathEffectToPath could have generated an empty path
+        if (skPath->isEmpty())
+        {
+            InitPathObjectEmptyPath(gpu, fPathID);
+            fShouldStroke = false;
+            fShouldFill = false;
+        }
+        else        
+        {
+            bool didInit = false;
+            if (stroke.needToApply() && stroke.getCap() != SkPaint::kButt_Cap)
+            {
+                // Skia stroking and NVPR stroking differ with respect to stroking
+                // end caps of empty subpaths.
+                // Convert stroke to fill if path contains empty subpaths.
+                didInit = InitPathObjectPathDataCheckingDegenerates(gpu, fPathID, *skPath);
+                if (!didInit)
+                {
+                    if (!tmpPath.isValid())
+                    {
+                        tmpPath.init();
+                    }
+                    SkAssertResult(stroke.applyToPath(tmpPath.get(), *skPath));
+                    skPath = tmpPath.get();
+                    stroke.setFillStyle();
+                }
+            }
 
-			if (!didInit)
-			{
-				InitPathObjectPathData(gpu, fPathID, *skPath);
-			}
+            if (!didInit)
+            {
+                InitPathObjectPathData(gpu, fPathID, *skPath);
+            }
 
-			fShouldStroke = stroke.needToApply();
-			fShouldFill = stroke.isFillStyle() ||
-				stroke.getStyle() == SkStrokeRec::kStrokeAndFill_Style;
+            fShouldStroke = stroke.needToApply();
+            fShouldFill = stroke.isFillStyle() ||
+                stroke.getStyle() == SkStrokeRec::kStrokeAndFill_Style;
 
-			fFillType = convert_skpath_filltype(skPath->getFillType());
-			fBounds = skPath->getBounds();
-			SkScalar radius = stroke.getInflationRadius();
-			fBounds.outset(radius, radius);
-			if (fShouldStroke)
-			{
-				InitPathObjectStroke(gpu, fPathID, stroke);
-			}
-		}
+            fFillType = convert_skpath_filltype(skPath->getFillType());
+            fBounds = skPath->getBounds();
+            SkScalar radius = stroke.getInflationRadius();
+            fBounds.outset(radius, radius);
+            if (fShouldStroke)
+            {
+                InitPathObjectStroke(gpu, fPathID, stroke);
+            }
+        }
     }
 
     this->registerWithCache(SkBudgeted::kYes);

--- a/src/gpu/gl/GrGLPath.cpp
+++ b/src/gpu/gl/GrGLPath.cpp
@@ -287,25 +287,19 @@ GrGLPath::GrGLPath(GrGLGpu* gpu, const SkPath& origSkPath, const GrStyle& style)
         }
 
         // applyPathEffectToPath could have generated an empty path
-        if (skPath->isEmpty())
-        {
+        if (skPath->isEmpty()) {
             InitPathObjectEmptyPath(gpu, fPathID);
             fShouldStroke = false;
             fShouldFill = false;
-        }
-        else        
-        {
+        } else {
             bool didInit = false;
-            if (stroke.needToApply() && stroke.getCap() != SkPaint::kButt_Cap)
-            {
+            if (stroke.needToApply() && stroke.getCap() != SkPaint::kButt_Cap) {
                 // Skia stroking and NVPR stroking differ with respect to stroking
                 // end caps of empty subpaths.
                 // Convert stroke to fill if path contains empty subpaths.
                 didInit = InitPathObjectPathDataCheckingDegenerates(gpu, fPathID, *skPath);
-                if (!didInit)
-                {
-                    if (!tmpPath.isValid())
-                    {
+                if (!didInit) {
+                    if (!tmpPath.isValid()) {
                         tmpPath.init();
                     }
                     SkAssertResult(stroke.applyToPath(tmpPath.get(), *skPath));
@@ -314,8 +308,7 @@ GrGLPath::GrGLPath(GrGLGpu* gpu, const SkPath& origSkPath, const GrStyle& style)
                 }
             }
 
-            if (!didInit)
-            {
+            if (!didInit) {
                 InitPathObjectPathData(gpu, fPathID, *skPath);
             }
 
@@ -327,8 +320,7 @@ GrGLPath::GrGLPath(GrGLGpu* gpu, const SkPath& origSkPath, const GrStyle& style)
             fBounds = skPath->getBounds();
             SkScalar radius = stroke.getInflationRadius();
             fBounds.outset(radius, radius);
-            if (fShouldStroke)
-            {
+            if (fShouldStroke) {
                 InitPathObjectStroke(gpu, fPathID, stroke);
             }
         }


### PR DESCRIPTION
It's possible to draw a dashed line that measures as 0 distance in `SkDashPath::InternalFilter`, which results in returning an empty path from `style.applyPathEffectToPath`. This trips an assert in `InitPathObjectPathData`.

I just added a check for this case, and it runs the same logic as if the original path had been empty.