### PR TITLE
Fix SkNx::FromBits to not rely on little endian

### DIFF
--- a/include/private/SkNx.h
+++ b/include/private/SkNx.h
@@ -286,13 +286,19 @@ private:
 
     template <typename Bits>
     AI static T FromBits(Bits bits) {
-        static_assert(std::is_pod<T   >::value &&
-                      std::is_pod<Bits>::value &&
-                      sizeof(T) <= sizeof(Bits), "");
         T val;
-        memcpy(&val, &bits, sizeof(T));
+        FromBits(val, bits);
         return val;
     }
+    template <typename U, typename Bits>
+    AI static void FromBits(U& v, Bits bits) {
+        static_assert(std::is_integral<U   >::value &&
+                      std::is_integral<Bits>::value);
+        v = bits;
+    }
+    AI static void FromBits(float& v, int32_t bits)  { memcpy(&v, &bits, sizeof(v)); }
+    AI static void FromBits(double& v, int64_t bits) { memcpy(&v, &bits, sizeof(v)); }
+
 };
 
 // Allow scalars on the left or right of binary operators, and things like +=, &=, etc.


### PR DESCRIPTION
The old implementation used memcpy between integers of different size,
giving rise to different behaviour depending on host endianness.
This new imlementation mirrors the ToBits implementation in that memcpy
is only used when floats are involved, and then only between objects
of the same size.

---

Specifically the old implementation would fail when performing  a `&` between two `Sk16b` (as is done in `blit_mask_d32_a8_black`) on a big endian system.  The expression `ToBits(fVal) & ToBits(y.fVal)` would see the `uint8_t` operands promoted to `unsigned int`, and then `FromBits` would copy the first (most significant) byte of that int into `fVal`.