### PR TITLE
fix skia crash in GrOpsTask::onExecute when application enter background on iOS

### DIFF
--- a/include/gpu/GrConfig.h
+++ b/include/gpu/GrConfig.h
@@ -11,6 +11,9 @@
 
 #include "include/core/SkTypes.h"
 
+extern bool isGpuRenderDisabled();
+extern void setGpuRenderDisabled(bool disabled);
+
 /**
  *  Gr defines are set to 0 or 1, rather than being undefined or defined
  */

--- a/src/gpu/GrDrawingManager.cpp
+++ b/src/gpu/GrDrawingManager.cpp
@@ -85,6 +85,9 @@ bool GrDrawingManager::flush(
         const GrBackendSurfaceMutableState* newState) {
     GR_CREATE_TRACE_MARKER_CONTEXT("GrDrawingManager", "flush", fContext);
 
+    if (isGpuRenderDisabled()) {
+        return false;
+    }
     if (fFlushing || this->wasAbandoned()) {
         if (info.fSubmittedProc) {
             info.fSubmittedProc(info.fSubmittedContext, false);
@@ -254,6 +257,9 @@ bool GrDrawingManager::flush(
     opMemoryPool->isEmpty();
 #endif
 
+    if (isGpuRenderDisabled()) {
+        return false;
+    }
     gpu->executeFlushInfo(proxies, access, info, newState);
 
     // Give the cache a chance to purge resources that become purgeable due to flushing.
@@ -300,6 +306,10 @@ bool GrDrawingManager::executeRenderTasks(int startIndex, int stopIndex, GrOpFlu
         }
     }
 #endif
+
+    if (isGpuRenderDisabled()) {
+        return false;
+    }
 
     bool anyRenderTasksExecuted = false;
 
@@ -480,6 +490,9 @@ GrSemaphoresSubmitted GrDrawingManager::flushSurfaces(
         SkSurface::BackendSurfaceAccess access,
         const GrFlushInfo& info,
         const GrBackendSurfaceMutableState* newState) {
+    if (isGpuRenderDisabled()) {
+        return GrSemaphoresSubmitted::kNo;
+    }
     if (this->wasAbandoned()) {
         if (info.fSubmittedProc) {
             info.fSubmittedProc(info.fSubmittedContext, false);

--- a/src/gpu/GrOpsTask.cpp
+++ b/src/gpu/GrOpsTask.cpp
@@ -546,6 +546,9 @@ bool GrOpsTask::onExecute(GrOpFlushState* flushState) {
     if (this->isNoOp() || (fClippedContentBounds.isEmpty() && fColorLoadOp != GrLoadOp::kDiscard)) {
         return false;
     }
+    if (isGpuRenderDisabled()) {
+        return false;
+    }
 
     SkASSERT(this->numTargets() == 1);
     GrRenderTargetProxy* proxy = this->target(0).proxy()->asRenderTargetProxy();

--- a/src/gpu/GrRenderTask.cpp
+++ b/src/gpu/GrRenderTask.cpp
@@ -12,6 +12,10 @@
 #include "src/gpu/GrTextureProxyPriv.h"
 #include "src/gpu/GrTextureResolveRenderTask.h"
 
+static std::atomic<bool> gGpuRenderDisabled = false;
+bool isGpuRenderDisabled() { return gGpuRenderDisabled; }
+void setGpuRenderDisabled(bool disabled) { gGpuRenderDisabled = disabled; }
+
 uint32_t GrRenderTask::CreateUniqueID() {
     static std::atomic<uint32_t> nextID{1};
     uint32_t id;

--- a/src/gpu/GrRenderTask.h
+++ b/src/gpu/GrRenderTask.h
@@ -34,7 +34,12 @@ public:
 
     // These two methods are only invoked at flush time
     void prepare(GrOpFlushState* flushState);
-    bool execute(GrOpFlushState* flushState) { return this->onExecute(flushState); }
+    bool execute(GrOpFlushState* flushState) {
+        if (isGpuRenderDisabled()) {
+            return false;
+        }
+        return this->onExecute(flushState);
+    }
 
     virtual bool requiresExplicitCleanup() const { return false; }
 

--- a/src/gpu/ops/GrOp.h
+++ b/src/gpu/ops/GrOp.h
@@ -227,6 +227,9 @@ public:
     /** Issues the op's commands to GrGpu. */
     void execute(GrOpFlushState* state, const SkRect& chainBounds) {
         TRACE_EVENT0("skia.gpu", name());
+        if (isGpuRenderDisabled()) {
+            return;
+        }
         this->onExecute(state, chainBounds);
     }
 


### PR DESCRIPTION
Fixes：[flutter#72261] flutter/flutter#72261

I add a flag to disable gpu render task when application enter background on iOS；
disable GPU render in applicationWillResignActive, and restore in applicationBecameActive.