### PR TITLE
Update package.json to include the repository

### DIFF
--- a/modules/canvaskit/npm_build/package.json
+++ b/modules/canvaskit/npm_build/package.json
@@ -11,6 +11,11 @@
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/google/skia.git",
+    "directory": "modules/canvaskit/npm-build"
+  },
   "scripts": {
     "dtslint": "dtslint types"
   },

--- a/modules/canvaskit/package.json
+++ b/modules/canvaskit/package.json
@@ -13,6 +13,11 @@
     "karma-jasmine": "~4.0.1",
     "requirejs": "~2.3.5"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/google/skia.git",
+    "directory": "modules/canvaskit"
+  },
   "scripts": {
     "test": "make test-continuous"
   },

--- a/modules/pathkit/npm-asmjs/package.json
+++ b/modules/pathkit/npm-asmjs/package.json
@@ -7,6 +7,11 @@
   "bugs": {
     "url": "https://bugs.chromium.org/p/skia/issues/entry"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/google/skia.git",
+    "directory": "modules/pathkit/npm-asmjs"
+  },
   "permsRepo": "skia-dev/.github",
   "publishConfig": {
     "registry":"https://wombat-dressing-room.appspot.com"

--- a/modules/pathkit/npm-wasm/package.json
+++ b/modules/pathkit/npm-wasm/package.json
@@ -7,6 +7,11 @@
   "bugs": {
     "url": "https://bugs.chromium.org/p/skia/issues/entry"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/google/skia.git",
+    "directory": "modules/pathkit/npm-wasm"
+  },
   "permsRepo": "skia-dev/.github",
   "publishConfig": {
     "registry":"https://wombat-dressing-room.appspot.com"

--- a/modules/pathkit/package.json
+++ b/modules/pathkit/package.json
@@ -14,6 +14,11 @@
     "karma-jasmine": "~4.0.1",
     "requirejs": "~2.3.5"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/google/skia.git",
+    "directory": "modules/pathkit"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR.

Published NPM packages with repository information:
• canvaskit-local
• canvaskit-wasm
• pathkit-local
• pathkit-asmjs
• pathkit-wasm