### PR TITLE
Fix EmbindObject's deleteLater to deleteAfter

### DIFF
--- a/modules/canvaskit/npm_build/types/index.d.ts
+++ b/modules/canvaskit/npm_build/types/index.d.ts
@@ -521,7 +521,7 @@ export interface Camera {
 export interface EmbindObject<T extends EmbindObject<T>> {
     clone(): T;
     delete(): void;
-    deleteAfter(): void;
+    deleteLater(): void;
     isAliasOf(other: any): boolean;
     isDeleted(): boolean;
 }


### PR DESCRIPTION
I found that CanvasKit's `EmbindObject` type has wrong function name, `deleteAfter`.

I cound't find any information of function `deleteAfter` even in google searching. so i digged it.

![image](https://user-images.githubusercontent.com/3580430/132103177-9c7c32a3-2107-4b97-9698-f52da5833ba1.png)

I have no idea with `deleteAfter`, but `EmbindObject` has the function name `deleteLater`, not `deleteAfter`.

Below is the code of Embind.
https://github.com/emscripten-core/emscripten/blob/dd5733ac80881e55e1f6757caabf617b6b2a7cec/src/embind/embind.js#L1782