### PR TITLE
fix fontMgr.makeTypefaceFromData type name

### DIFF
--- a/modules/canvaskit/npm_build/types/index.d.ts
+++ b/modules/canvaskit/npm_build/types/index.d.ts
@@ -1768,7 +1768,7 @@ export interface FontMgr extends EmbindObject<FontMgr> {
      * Create a typeface for the specified bytes and return it.
      * @param fontData
      */
-    makeTypefaceFromData(fontData: ArrayBuffer): Typeface;
+    MakeTypefaceFromData(fontData: ArrayBuffer): Typeface;
 }
 
 /**


### PR DESCRIPTION
fontMgr doesn't export the function named `makeTypefaceFromData`.

it has `**M**akeTypefaceFromData`.

