### PR TITLE
Call this._resetContext() at end of makeImageFromTextureSource

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -82,6 +82,7 @@ Mike Reed <mike@reedtribe.org>
 Cary Clark <cclark2@gmail.com>
 Matthew Blanchard <matthewrblanchard@gmail.com>
 Oliver Dawes <olliedawes@gmail.com>
+namse <skatpgusskat@naver.com>
 
 # Trusted service accounts.
 Recipe roller SA <recipe-mega-autoroller@chops-service-accounts.iam.gserviceaccount.com>

--- a/modules/canvaskit/webgl.js
+++ b/modules/canvaskit/webgl.js
@@ -273,6 +273,7 @@
           glCtx.texImage2D(glCtx.TEXTURE_2D, 0, glCtx.RGBA, glCtx.RGBA, glCtx.UNSIGNED_BYTE, src);
         }
         resetTexture(glCtx, info);
+        this._resetContext();
         return this.makeImageFromTexture(newTex, info);
       };
 


### PR DESCRIPTION
Issue : https://bugs.chromium.org/p/skia/issues/detail?id=13903
First, please read issue above.
After I change this, it works very well. I tested in my local with modified `canvaskit.js`.