### PR TITLE
emscripten builds on windows must use the .bat cc

### DIFF
--- a/gn/toolchain/BUILD.gn
+++ b/gn/toolchain/BUILD.gn
@@ -432,9 +432,15 @@ if (is_wasm) {
   gcc_like_toolchain("wasm") {
     cpu = "wasm"
     os = "wasm"
-    ar = "$skia_emsdk_dir/upstream/emscripten/emar"
-    cc = "$skia_emsdk_dir/upstream/emscripten/emcc"
-    cxx = "$skia_emsdk_dir/upstream/emscripten/em++"
+    if(host_os == "win"){
+      ar = "$skia_emsdk_dir/upstream/emscripten/emar.bat"
+      cc = "$skia_emsdk_dir/upstream/emscripten/emcc.bat"
+      cxx = "$skia_emsdk_dir/upstream/emscripten/em++.bat"
+    }else{
+      ar = "$skia_emsdk_dir/upstream/emscripten/emar"
+      cc = "$skia_emsdk_dir/upstream/emscripten/emcc"
+      cxx = "$skia_emsdk_dir/upstream/emscripten/em++"
+    }
     link = cxx
   }
 }


### PR DESCRIPTION
On windows, the `emar/emcc/em++` files are still sh scripts, which it can't run. Ninja tries to CreateProcess them and fails. Changing the ar/cc/cxx for the wasm toolchain to use the .bat files when running on windows fixes this.