### PR TITLE
Fix some emoji with modifer scalar render error 

### DIFF
--- a/modules/skunicode/include/SkUnicode.h
+++ b/modules/skunicode/include/SkUnicode.h
@@ -150,6 +150,9 @@ class SKUNICODE_API SkUnicode {
         static SkString convertUtf16ToUtf8(const std::u16string& utf16);
         static std::u16string convertUtf8ToUtf16(const char* utf8, int utf8Units);
         static std::u16string convertUtf8ToUtf16(const SkString& utf8);
+        static bool isEmoji(SkUnichar utf8);
+        static bool isEmojiModifier(SkUnichar utf8);
+        static bool isEmojiBase(SkUnichar utf8);
 
         template <typename Appender8, typename Appender16>
         bool extractUtfConversionMapping(SkSpan<const char> utf8, Appender8&& appender8, Appender16&& appender16) {

--- a/modules/skunicode/include/SkUnicode.h
+++ b/modules/skunicode/include/SkUnicode.h
@@ -151,8 +151,6 @@ class SKUNICODE_API SkUnicode {
         static std::u16string convertUtf8ToUtf16(const char* utf8, int utf8Units);
         static std::u16string convertUtf8ToUtf16(const SkString& utf8);
         static bool isEmoji(SkUnichar utf8);
-        static bool isEmojiModifier(SkUnichar utf8);
-        static bool isEmojiBase(SkUnichar utf8);
 
         template <typename Appender8, typename Appender16>
         bool extractUtfConversionMapping(SkSpan<const char> utf8, Appender8&& appender8, Appender16&& appender16) {

--- a/modules/skunicode/src/SkUnicode_icu.cpp
+++ b/modules/skunicode/src/SkUnicode_icu.cpp
@@ -568,14 +568,6 @@ bool SkUnicode::isEmoji(SkUnichar utf8) {
     return sk_u_hasBinaryProperty(utf8, UCHAR_EMOJI);
 }
 
-bool SkUnicode::isEmojiModifier(SkUnichar utf8) {
-    return sk_u_hasBinaryProperty(utf8, UCHAR_EMOJI_MODIFIER);
-}
-
-bool SkUnicode::isEmojiBase(SkUnichar utf8) {
-    return sk_u_hasBinaryProperty(utf8, UCHAR_EMOJI_MODIFIER_BASE);
-}
-
 std::unique_ptr<SkUnicode> SkUnicode::Make() {
     #if defined(SK_USING_THIRD_PARTY_ICU)
     if (!SkLoadICU()) {

--- a/modules/skunicode/src/SkUnicode_icu.cpp
+++ b/modules/skunicode/src/SkUnicode_icu.cpp
@@ -564,6 +564,18 @@ public:
     }
 };
 
+bool SkUnicode::isEmoji(SkUnichar utf8) {
+    return sk_u_hasBinaryProperty(utf8, UCHAR_EMOJI);
+}
+
+bool SkUnicode::isEmojiModifier(SkUnichar utf8) {
+    return sk_u_hasBinaryProperty(utf8, UCHAR_EMOJI_MODIFIER);
+}
+
+bool SkUnicode::isEmojiBase(SkUnichar utf8) {
+    return sk_u_hasBinaryProperty(utf8, UCHAR_EMOJI_MODIFIER_BASE);
+}
+
 std::unique_ptr<SkUnicode> SkUnicode::Make() {
     #if defined(SK_USING_THIRD_PARTY_ICU)
     if (!SkLoadICU()) {

--- a/modules/skunicode/src/SkUnicode_icu.h
+++ b/modules/skunicode/src/SkUnicode_icu.h
@@ -24,6 +24,7 @@
     SKICU_FUNC(u_iscntrl)             \
     SKICU_FUNC(u_isspace)             \
     SKICU_FUNC(u_isWhitespace)        \
+    SKICU_FUNC(u_hasBinaryProperty)   \
     SKICU_FUNC(u_strToUpper)          \
     SKICU_FUNC(ubidi_close)           \
     SKICU_FUNC(ubidi_getDirection)    \

--- a/src/ports/SkFontMgr_mac_ct.cpp
+++ b/src/ports/SkFontMgr_mac_ct.cpp
@@ -18,6 +18,7 @@
 #include <CoreGraphics/CoreGraphics.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <dlfcn.h>
+#include "modules/skunicode/include/SkUnicode.h"
 #endif
 
 #include "include/core/SkData.h"
@@ -507,6 +508,14 @@ protected:
         if (!string) {
             return nullptr;
         }
+#ifdef SK_BUILD_FOR_IOS
+        if (familyName == NULL && SkUnicode::isEmoji(character)) {
+            CFStringRef fontName = CFSTR("Apple Color Emoji");
+            CGFloat fontSize =16;
+            SkUniqueCFRef<CTFontRef> ret(CTFontCreateWithName(fontName, fontSize, NULL));
+            return SkTypeface_Mac::Make(std::move(ret), OpszVariation(), nullptr).release();
+        }
+#endif
         CFRange range = CFRangeMake(0, CFStringGetLength(string.get()));  // in UniChar units.
         SkUniqueCFRef<CTFontRef> fallbackFont(
                 CTFontCreateForString(familyFont.get(), string.get(), range));

--- a/src/ports/SkFontMgr_mac_ct.cpp
+++ b/src/ports/SkFontMgr_mac_ct.cpp
@@ -508,11 +508,9 @@ protected:
         if (!string) {
             return nullptr;
         }
-#ifdef SK_BUILD_FOR_IOS
+#if defined(SK_BUILD_FOR_IOS)
         if (familyName == NULL && SkUnicode::isEmoji(character)) {
-            CFStringRef fontName = CFSTR("Apple Color Emoji");
-            CGFloat fontSize =16;
-            SkUniqueCFRef<CTFontRef> ret(CTFontCreateWithName(fontName, fontSize, NULL));
+            SkUniqueCFRef<CTFontRef> ret(CTFontCreateWithName(CFSTR("AppleColorEmoji"), 16, NULL));
             return SkTypeface_Mac::Make(std::move(ret), OpszVariation(), nullptr).release();
         }
 #endif


### PR DESCRIPTION
What steps will reproduce the problem?
In flutter. Skia will render errors in rendering emojis which more than one Scalar. Like 1️⃣ (U+0031 U+FE0F  U+20E3)

flutter related issues:
https://github.com/flutter/flutter/issues/108720
https://github.com/flutter/flutter/issues/49627
https://github.com/flutter/flutter/issues/100964


What is the expected output? What do you see instead?
Render emoji nomarly.

What version of the product are you using? On what operating system?
I don't have more iPhone devices. I got two iPhones. 
One is iPhone 6, iOS 12.4.8, and it renders OK.
Another is iPhone 12 Pro, iOS 16.2. and it renders an error.

Please submit a code sample via fiddle.skia.org showing the issue.

Flutter demo:
```
import 'package:flutter/material.dart';

void main() {
  runApp(const TextApp());
  // runApp(const RandomPositionTextApp());
}

class TextApp extends StatelessWidget {
  const TextApp({super.key});

  @override
  Widget build(BuildContext context) {
    TextStyle myCustomFontStyle = const TextStyle(
      fontFamily: 'NotoColorEmoji-Regular',
    );
    return MaterialApp(
      home: Scaffold(
        body: Center(
          child: Column(
            mainAxisAlignment: MainAxisAlignment.center,
            children: <Widget>[

              Text(
                '1️⃣',
              ),
            ],
          ),
        ),
      ),
    );
  }
}
```


I tracked this bug. When using iPhone 6, iOS 12.4.8. It will fallback font 'Apple Color Emoji' And in iPhone 12 Pro, iOS 16.2 will fallback font '.LastResort' which will render '??' finally.


And I tried to fix this bug which the chromium project has similar issues:https://chromium.googlesource.com/chromium/src.git/+/7846480579c09efa317a65beb58c195a6a5bb352

