### PR TITLE
fix(*): fix links in canvaskit readme

### DIFF
--- a/modules/canvaskit/npm_build/README.md
+++ b/modules/canvaskit/npm_build/README.md
@@ -108,8 +108,8 @@ See more examples in `example.html` and `node.example.js`.
 
 # Filing bugs
 
-Please file bugs at [skbug.com](skbug.com).
-It may be convenient to use [our online fiddle](jsfiddle.skia.org/canvaskit) to demonstrate any issues encountered.
+Please file bugs at [https://skbug.com](skbug.com).
+It may be convenient to use [our online fiddle](https://jsfiddle.skia.org/canvaskit) to demonstrate any issues encountered.
 
 See CONTRIBUTING.md for more information on sending pull requests.
 


### PR DESCRIPTION
if you open https://www.npmjs.com/package/canvaskit-wasm and try to follow links it will open npm page. This PR fixes it