### PR TITLE
Remove --expose-wasm from documentation

### DIFF
--- a/modules/canvaskit/npm_build/README.md
+++ b/modules/canvaskit/npm_build/README.md
@@ -31,8 +31,6 @@ To use CanvasKit in Node, it's similar to the browser:
         // Code goes here using CanvasKit
     });
 
-With node, you also need to supply the `--expose-wasm` flag.
-
 ## WebPack
 
 WebPack's support for WASM is still somewhat experimental, but CanvasKit can be


### PR DESCRIPTION
documentation suggests to use --expose-wasm flag working with node. But I can't find it in nodejs documentation

We use skia without specifying this flag and it works.

Our node version is 14