### PR TITLE
feat(*): add entry points for canvaskit

### DIFF
--- a/modules/canvaskit/npm_build/README.md
+++ b/modules/canvaskit/npm_build/README.md
@@ -24,7 +24,7 @@ As with all npm packages, there's a freely available CDN via unpkg.com:
 ## Node
 To use CanvasKit in Node, it's similar to the browser:
 
-    const CanvasKitInit = require('/node_modules/canvaskit-wasm/bin/canvaskit.js');
+    const CanvasKitInit = require('canvaskit-wasm/bin/canvaskit.js');
     CanvasKitInit({
         locateFile: (file) => __dirname + '/bin/'+file,
     }).then((CanvasKit) => {
@@ -65,6 +65,57 @@ Then, add the following configuration change to the node section of the config:
         fs: 'empty'
     };
 
+
+# Different canvaskit bundles
+
+`canvaskit-wasm` includes 3 types of bundles:
+
+* default `./bin/canvaskit.js` - Basic canvaskit functionality
+
+
+```javascript
+const InitCanvasKit = require('canvaskit-wasm/bin/canvaskit');
+```
+
+* full `./bin/full/canvaskit.js` - includes [Skottie](https://skia.org/docs/user/modules/skottie/) and other libraries
+
+```javascript
+const InitCanvasKit = require('canvaskit-wasm/bin/full/canvaskit');
+```
+
+* profiling `./bin/profiling/canvaskit.js` - the same as `full` but contains full names of wasm functions called internally
+
+```javascript
+const InitCanvasKit = require('canvaskit-wasm/bin/profiling/canvaskit');
+```
+
+# ES6 import and node entrypoints
+
+This package also exposes [entrypoints](https://nodejs.org/api/packages.html#package-entry-points)
+
+```javascript
+import InitCanvasKit from 'canvaskit-wasm'; // default
+```
+
+```javascript
+import InitCanvasKit from 'canvaskit-wasm/full';
+```
+
+```javascript
+import InitCanvasKit from 'canvaskit-wasm/profiling';
+```
+
+If you use [typescript](https://www.typescriptlang.org/)
+
+you need to add this setting to your tsconfig.json
+
+```json
+{
+    "compilerOptions": {
+        "compilerOptions": "nodenext",
+    }
+}
+```
 
 # Using the CanvasKit API
 

--- a/modules/canvaskit/npm_build/README.md
+++ b/modules/canvaskit/npm_build/README.md
@@ -107,12 +107,12 @@ import InitCanvasKit from 'canvaskit-wasm/profiling';
 
 If you use [typescript](https://www.typescriptlang.org/)
 
-you need to add this setting to your tsconfig.json
+you need to enable [resolvePackageJsonExports](https://www.typescriptlang.org/tsconfig#resolvePackageJsonExports) in your `tsconfig.json`
 
 ```json
 {
     "compilerOptions": {
-        "compilerOptions": "nodenext",
+        "resolvePackageJsonExports": true
     }
 }
 ```

--- a/modules/canvaskit/npm_build/package.json
+++ b/modules/canvaskit/npm_build/package.json
@@ -28,17 +28,7 @@
       "import": "./bin/canvaskit.js",
       "types": "./types/index.d.ts"
     },
-    "./bin/canvaskit": {
-      "require": "./bin/canvaskit.js",
-      "import": "./bin/canvaskit.js",
-      "types": "./types/index.d.ts"
-    },
     "./full": {
-      "require": "./bin/full/canvaskit.js",
-      "import": "./bin/full/canvaskit.js",
-      "types": "./types/index.d.ts"
-    },
-    "./bin/full/canvaskit": {
       "require": "./bin/full/canvaskit.js",
       "import": "./bin/full/canvaskit.js",
       "types": "./types/index.d.ts"
@@ -48,7 +38,32 @@
       "import": "./bin/profiling/canvaskit.js",
       "types": "./types/index.d.ts"
     },
+    "./bin/canvaskit": {
+      "require": "./bin/canvaskit.js",
+      "import": "./bin/canvaskit.js",
+      "types": "./types/index.d.ts"
+    },
+    "./bin/canvaskit.js": {
+      "require": "./bin/canvaskit.js",
+      "import": "./bin/canvaskit.js",
+      "types": "./types/index.d.ts"
+    },
+    "./bin/full/canvaskit": {
+      "require": "./bin/full/canvaskit.js",
+      "import": "./bin/full/canvaskit.js",
+      "types": "./types/index.d.ts"
+    },
+    "./bin/full/canvaskit.js": {
+      "require": "./bin/full/canvaskit.js",
+      "import": "./bin/full/canvaskit.js",
+      "types": "./types/index.d.ts"
+    },
     "./bin/profiling/canvaskit": {
+      "require": "./bin/profiling/canvaskit.js",
+      "import": "./bin/profiling/canvaskit.js",
+      "types": "./types/index.d.ts"
+    },
+    "./bin/profiling/canvaskit.js": {
       "require": "./bin/profiling/canvaskit.js",
       "import": "./bin/profiling/canvaskit.js",
       "types": "./types/index.d.ts"

--- a/modules/canvaskit/npm_build/package.json
+++ b/modules/canvaskit/npm_build/package.json
@@ -28,9 +28,24 @@
       "import": "./bin/canvaskit.js",
       "types": "./types/index.d.ts"
     },
+    "./bin/canvaskit": {
+      "require": "./bin/canvaskit.js",
+      "import": "./bin/canvaskit.js",
+      "types": "./types/index.d.ts"
+    },
     "./full": {
       "require": "./bin/full/canvaskit.js",
       "import": "./bin/full/canvaskit.js",
+      "types": "./types/index.d.ts"
+    },
+    "./bin/full/canvaskit": {
+      "require": "./bin/full/canvaskit.js",
+      "import": "./bin/full/canvaskit.js",
+      "types": "./types/index.d.ts"
+    },
+    "./bin/profiling/canvaskit": {
+      "require": "./bin/profiling/canvaskit.js",
+      "import": "./bin/profiling/canvaskit.js",
       "types": "./types/index.d.ts"
     },
     "./profiling": {

--- a/modules/canvaskit/npm_build/package.json
+++ b/modules/canvaskit/npm_build/package.json
@@ -43,12 +43,12 @@
       "import": "./bin/full/canvaskit.js",
       "types": "./types/index.d.ts"
     },
-    "./bin/profiling/canvaskit": {
+    "./profiling": {
       "require": "./bin/profiling/canvaskit.js",
       "import": "./bin/profiling/canvaskit.js",
       "types": "./types/index.d.ts"
     },
-    "./profiling": {
+    "./bin/profiling/canvaskit": {
       "require": "./bin/profiling/canvaskit.js",
       "import": "./bin/profiling/canvaskit.js",
       "types": "./types/index.d.ts"

--- a/modules/canvaskit/npm_build/package.json
+++ b/modules/canvaskit/npm_build/package.json
@@ -21,5 +21,22 @@
     "typescript": "4.7.4",
     "@definitelytyped/header-parser": "0.0.121",
     "@webgpu/types": "0.1.21"
+  },
+  "exports": {
+    ".": {
+      "require": "./bin/canvaskit.js",
+      "import": "./bin/canvaskit.js",
+      "types": "./types/index.d.ts"
+    },
+    "./full": {
+      "require": "./bin/full/canvaskit.js",
+      "import": "./bin/full/canvaskit.js",
+      "types": "./types/index.d.ts"
+    },
+    "./profiling": {
+      "require": "./bin/profiling/canvaskit.js",
+      "import": "./bin/profiling/canvaskit.js",
+      "types": "./types/index.d.ts"
+    }
   }
 }


### PR DESCRIPTION
Hello! 

I added more details about how to import skia, and also added additional entrypoints to npm package

It was a little bit tricky to figure out how to use skottie.
The problem is that for all entrypoints canvas kit has just one file of ts definitions