### PR TITLE
refactor(*): make canvaskit init parameter optional

### DIFF
--- a/modules/canvaskit/npm_build/types/index.d.ts
+++ b/modules/canvaskit/npm_build/types/index.d.ts
@@ -1,7 +1,7 @@
 // Minimum TypeScript Version: 4.4
 /// <reference types="@webgpu/types" />
 
-export default function CanvasKitInit(opts: CanvasKitInitOptions): Promise<CanvasKit>;
+export default function CanvasKitInit(opts?: CanvasKitInitOptions): Promise<CanvasKit>;
 
 export interface CanvasKitInitOptions {
     /**


### PR DESCRIPTION
According existing documentation, canvaskitInit settings are not required

https://github.com/google/skia/blob/main/modules/canvaskit/npm_build/README.md?plain=1#L42
Without passing this param everything works as expected