### PR TITLE
chore(canvaskit): up version of package.json

### DIFF
--- a/modules/canvaskit/npm_build/package.json
+++ b/modules/canvaskit/npm_build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canvaskit-wasm",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "description": "A WASM version of Skia's Canvas API",
   "main": "bin/canvaskit.js",
   "homepage": "https://github.com/google/skia/tree/main/modules/canvaskit",


### PR DESCRIPTION
Hello! I expected all PRs
would be released after merge
https://github.com/google/skia/pull/135
https://github.com/google/skia/pull/134
https://github.com/google/skia/pull/133

But it's seems like it's not automatic
Should I just bump version?

Thank you!