### PR TITLE
fix: When installing skia on Windows, using emsdk.py, the option --permanent is required for setting environment variables.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -92,7 +92,7 @@ Yandex LLC <*@yandex-team.ru>
 Yong-Hwan Baek <meisterdevhwan@gmail.com>
 Zhuo Qingliang <zhuo.dev@gmail.com>
 Zoho Corporation Private Limited <*@zohocorp.com>
-Soso Tsertsvadze <totorotomoney@gmail.com>
+Soso Tsertsvadze <sosotsertsvadze2@gmail.com>
 
 # Trusted service accounts.
 GitHub Dependabot <(\d+)\+dependabot\[bot\]@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -92,6 +92,7 @@ Yandex LLC <*@yandex-team.ru>
 Yong-Hwan Baek <meisterdevhwan@gmail.com>
 Zhuo Qingliang <zhuo.dev@gmail.com>
 Zoho Corporation Private Limited <*@zohocorp.com>
+Dima Parzhitsky <totorotomoney@gmail.com> <sosotsertsvadze2@gmail.com>
 
 # Trusted service accounts.
 GitHub Dependabot <(\d+)\+dependabot\[bot\]@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -92,7 +92,7 @@ Yandex LLC <*@yandex-team.ru>
 Yong-Hwan Baek <meisterdevhwan@gmail.com>
 Zhuo Qingliang <zhuo.dev@gmail.com>
 Zoho Corporation Private Limited <*@zohocorp.com>
-Soso Tsertsvadze <totorotomoney@gmail.com> <sosotsertsvadze2@gmail.com>
+Soso Tsertsvadze <totorotomoney@gmail.com>
 
 # Trusted service accounts.
 GitHub Dependabot <(\d+)\+dependabot\[bot\]@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -92,7 +92,7 @@ Yandex LLC <*@yandex-team.ru>
 Yong-Hwan Baek <meisterdevhwan@gmail.com>
 Zhuo Qingliang <zhuo.dev@gmail.com>
 Zoho Corporation Private Limited <*@zohocorp.com>
-Dima Parzhitsky <totorotomoney@gmail.com> <sosotsertsvadze2@gmail.com>
+Soso Tsertsvadze <totorotomoney@gmail.com> <sosotsertsvadze2@gmail.com>
 
 # Trusted service accounts.
 GitHub Dependabot <(\d+)\+dependabot\[bot\]@users.noreply.github.com>

--- a/bin/activate-emsdk
+++ b/bin/activate-emsdk
@@ -23,12 +23,12 @@ def main():
         # for the latest version
         return
     try:
-        subprocess.check_call([sys.executable, EMSDK_PATH, 'install', EMSDK_VERSION])
+        subprocess.check_call([sys.executable, EMSDK_PATH, 'install', "--permanent", EMSDK_VERSION])
     except subprocess.CalledProcessError:
         print ('Failed to install emsdk')
         return 1
     try:
-        subprocess.check_call([sys.executable, EMSDK_PATH, 'activate', EMSDK_VERSION])
+        subprocess.check_call([sys.executable, EMSDK_PATH, 'activate', "--permanent", EMSDK_VERSION])
     except subprocess.CalledProcessError:
         print ('Failed to activate emsdk')
         return 1


### PR DESCRIPTION
When installing skia on Windows, using emsdk.py, the option --permanent is required for setting environment variables.

- If the `--permanent` option is passed, then the environment variables are set permanently for the current user. 