### PR TITLE
Implement onMatchFamilyStyle for SkParagraph.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -64,6 +64,7 @@ Nils André-Chang <nils@nilsand.re>
 Ning Liu <ningliu@invisionapp.com>
 Noah Lavine <noah.b.lavine@gmail.com>
 Oliver Dawes <olliedawes@gmail.com>
+Omeid Matten <contact@omeid.me>
 Opera Software ASA <*@opera.com>
 Pavel Krajcevski <pavel@cs.unc.edu>
 Petar Kirov <petar.p.kirov@gmail.com>

--- a/modules/skparagraph/include/TypefaceFontProvider.h
+++ b/modules/skparagraph/include/TypefaceFontProvider.h
@@ -47,9 +47,7 @@ public:
     sk_sp<SkFontStyleSet> onMatchFamily(const char familyName[]) const override;
 
     sk_sp<SkFontStyleSet> onCreateStyleSet(int) const override { return nullptr; }
-    sk_sp<SkTypeface> onMatchFamilyStyle(const char[], const SkFontStyle&) const override {
-        return nullptr;
-    }
+    sk_sp<SkTypeface> onMatchFamilyStyle(const char familyName[], const SkFontStyle& pattern) const override;
     sk_sp<SkTypeface> onMatchFamilyStyleCharacter(const char[], const SkFontStyle&,
                                                   const char*[], int,
                                                   SkUnichar) const override {

--- a/modules/skparagraph/src/TypefaceFontProvider.cpp
+++ b/modules/skparagraph/src/TypefaceFontProvider.cpp
@@ -24,6 +24,16 @@ sk_sp<SkFontStyleSet> TypefaceFontProvider::onMatchFamily(const char familyName[
     return nullptr;
 }
 
+
+sk_sp<SkTypeface> TypefaceFontProvider::onMatchFamilyStyle(const char familyName[], const SkFontStyle& pattern) const {
+    sk_sp<SkFontStyleSet> sset(this->matchFamily(familyName));
+    if (sset) {
+      return sset->matchStyle(pattern);
+    }
+
+    return nullptr;
+}
+
 size_t TypefaceFontProvider::registerTypeface(sk_sp<SkTypeface> typeface) {
     if (typeface == nullptr) {
         return 0;


### PR DESCRIPTION
    Implement onMatchFamilyStyle for SkParagraph.
    
    CanvasKit uses skparagraph's TypefaceFontProvider which is fine and
    dandy but it exposes a very limited interface to FontMgr, with
    matchFamilyStyle as the only option for finding typefaces and fonts.
    
    Without implementing this method, it is not possible to use custom fonts
    on wasm as calling matchFamilyStyle with current onMatchFamilyStyle is a
    noop and returns null.