### PR TITLE
Fix SVG filter property propagation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -77,6 +77,7 @@ Pavel Krajcevski <pavel@cs.unc.edu>
 Petar Kirov <petar.p.kirov@gmail.com>
 Ping Wang <ping.wang@amd.com>
 Raul Tambre <raul@tambre.ee>
+Roman Petrenko <roman@canva.com>
 Safa Sofuoglu <safasofuoglu@gmail.com>
 Samsung <*@samsung.com>
 Samsung Open Source Group <*@osg.samsung.com>

--- a/modules/svg/include/SkSVGFilter.h
+++ b/modules/svg/include/SkSVGFilter.h
@@ -15,6 +15,9 @@ class SK_API SkSVGFilter final : public SkSVGHiddenContainer {
 public:
     static sk_sp<SkSVGFilter> Make() { return sk_sp<SkSVGFilter>(new SkSVGFilter()); }
 
+    /** Propagates any inherited presentation attributes in the given context. */
+    void applyProperties(SkSVGRenderContext*) const;
+
     sk_sp<SkImageFilter> buildFilterDAG(const SkSVGRenderContext&) const;
 
     SVG_ATTR(X, SkSVGLength, SkSVGLength(-10, SkSVGLength::Unit::kPercentage))


### PR DESCRIPTION
Skia currently has trouble understanding what color space to use when it comes to filters. In the examples below, Skia would default to `linearRGB` as the value for `color-interpolation-filters` attribute, despite `sRGB` being specified:

## Example 1:
```xml
<filter id="a" color-interpolation-filters="sRGB">
    <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 0 1 0"/>
</filter>
```
Skia fiddle: https://fiddle.skia.org/c/ab9b330ebb5d737cfe5db3335d7a33d7
![filter](https://github.com/google/skia/assets/5735967/f99f6f00-49e7-4f2d-9721-6505874b57ed)


## Example 2:
```xml
<filter id="a">
    <feColorMatrix color-interpolation-filters="sRGB" values="0 0 0 0 0 0 0 0 0 0 1 1 1 0 0 0 0 0 1 0"/>
</filter>
```
Skia fiddle: https://fiddle.skia.org/c/8da8a28be3ea4c4d56d20c673ec51aed
![feColorMatrix](https://github.com/google/skia/assets/5735967/d638e8bc-0ab5-49ee-9d6b-8c988b731873)
