### PR TITLE
Fix crash rendering emoji on macOS with FontCollection that lacks def…

### DIFF
--- a/modules/skparagraph/src/FontCollection.cpp
+++ b/modules/skparagraph/src/FontCollection.cpp
@@ -176,10 +176,12 @@ sk_sp<SkTypeface> FontCollection::defaultEmojiFallback(SkUnichar emojiStart,
     for (const auto& manager : this->getFontManagerOrder()) {
         std::vector<const char*> bcp47;
 #if defined(SK_BUILD_FOR_MAC) || defined(SK_BUILD_FOR_IOS)
-        sk_sp<SkTypeface> emojiTypeface =
-            fDefaultFontManager->matchFamilyStyle(kColorEmojiFontMac, SkFontStyle());
-        if (emojiTypeface != nullptr) {
-            return emojiTypeface;
+        if (fDefaultFontManager) {
+            sk_sp<SkTypeface> emojiTypeface =
+                fDefaultFontManager->matchFamilyStyle(kColorEmojiFontMac, SkFontStyle());
+            if (emojiTypeface != nullptr) {
+                return emojiTypeface;
+            }
         }
 #else
           bcp47.push_back(kColorEmojiLocale);


### PR DESCRIPTION
…ault font manager

FontCollection checks if fDefaultFontManager is non-null in various places before using it, except when determining the emoji fallback font. This can cause a crash when the FontCollection was not initialized with a default font manager.

This is reproducible for me on macOS with the 🍃 emoji.