### PR TITLE
allow `SkImage::asyncRescaleAndReadPixels()` to work async on WebGL

### DIFF
--- a/include/gpu/gl/GrGLFunctions.h
+++ b/include/gpu/gl/GrGLFunctions.h
@@ -95,6 +95,7 @@ using GrGLGenSamplersFn = GrGLvoid GR_GL_FUNCTION_TYPE(GrGLsizei count, GrGLuint
 using GrGLGenTexturesFn = GrGLvoid GR_GL_FUNCTION_TYPE(GrGLsizei n, GrGLuint* textures);
 using GrGLGenVertexArraysFn = GrGLvoid GR_GL_FUNCTION_TYPE(GrGLsizei n, GrGLuint* arrays);
 using GrGLGetBufferParameterivFn = GrGLvoid GR_GL_FUNCTION_TYPE(GrGLenum target, GrGLenum pname, GrGLint* params);
+using GrGLGetBufferSubDataFn = GrGLvoid GR_GL_FUNCTION_TYPE(GrGLenum target, GrGLintptr offset, GrGLsizeiptr size, GrGLvoid* data);
 using GrGLGetErrorFn = GrGLenum GR_GL_FUNCTION_TYPE();
 using GrGLGetFramebufferAttachmentParameterivFn = GrGLvoid GR_GL_FUNCTION_TYPE(GrGLenum target, GrGLenum attachment, GrGLenum pname, GrGLint* params);
 using GrGLGetFloatvFn = GrGLvoid GR_GL_FUNCTION_TYPE(GrGLenum pname, GrGLfloat* params);

--- a/include/gpu/gl/GrGLInterface.h
+++ b/include/gpu/gl/GrGLInterface.h
@@ -165,6 +165,7 @@ public:
         GrGLFunction<GrGLGenTexturesFn> fGenTextures;
         GrGLFunction<GrGLGenVertexArraysFn> fGenVertexArrays;
         GrGLFunction<GrGLGetBufferParameterivFn> fGetBufferParameteriv;
+        GrGLFunction<GrGLGetBufferSubDataFn> fGetBufferSubData;
         GrGLFunction<GrGLGetErrorFn> fGetError;
         GrGLFunction<GrGLGetFramebufferAttachmentParameterivFn> fGetFramebufferAttachmentParameteriv;
         GrGLFunction<GrGLGetFloatvFn> fGetFloatv;

--- a/src/gpu/ganesh/GrGpuBuffer.cpp
+++ b/src/gpu/ganesh/GrGpuBuffer.cpp
@@ -83,6 +83,10 @@ bool GrGpuBuffer::updateData(const void* src, size_t offset, size_t size, bool p
     return this->onUpdateData(src, offset, size, preserve);
 }
 
+bool GrGpuBuffer::getData(void* dst, size_t offset, size_t size) {
+    return this->onGetData(dst, offset, size);
+}
+
 void GrGpuBuffer::ComputeScratchKeyForDynamicBuffer(size_t size,
                                                     GrGpuBufferType intendedType,
                                                     skgpu::ScratchKey* key) {

--- a/src/gpu/ganesh/GrGpuBuffer.h
+++ b/src/gpu/ganesh/GrGpuBuffer.h
@@ -96,6 +96,15 @@ public:
      */
     bool updateData(const void* src, size_t offset, size_t size, bool preserve);
 
+    /**
+     * Get the buffer data.
+     *
+     * WebGL's buffer can't be mapped to client side. Use this function to get the buffer data.
+     *
+     * @return returns true if the update succeeds, false otherwise.
+     */
+    bool getData(void* dst, size_t offset, size_t size);
+
     GrGpuBufferType intendedType() const { return fIntendedType; }
 
 protected:
@@ -129,6 +138,7 @@ private:
     virtual void onUnmap(MapType) = 0;
     virtual bool onClearToZero() = 0;
     virtual bool onUpdateData(const void* src, size_t offset, size_t size, bool preserve) = 0;
+    virtual bool onGetData(void* dst, size_t offset, size_t size) { return false; }
 
     size_t onGpuMemorySize() const override { return fSizeInBytes; }
     void onSetLabel() override{}

--- a/src/gpu/ganesh/gl/GrGLAssembleGLInterfaceAutogen.cpp
+++ b/src/gpu/ganesh/gl/GrGLAssembleGLInterfaceAutogen.cpp
@@ -93,6 +93,7 @@ sk_sp<const GrGLInterface> GrGLMakeAssembledGLInterface(void *ctx, GrGLGetProc g
     GET_PROC(GenBuffers);
     GET_PROC(GenTextures);
     GET_PROC(GetBufferParameteriv);
+    GET_PROC(GetBufferSubData);
     GET_PROC(GetError);
     GET_PROC(GetFloatv);
     GET_PROC(GetIntegerv);

--- a/src/gpu/ganesh/gl/GrGLAssembleWebGLInterfaceAutogen.cpp
+++ b/src/gpu/ganesh/gl/GrGLAssembleWebGLInterfaceAutogen.cpp
@@ -215,6 +215,7 @@ sk_sp<const GrGLInterface> GrGLMakeAssembledWebGLInterface(void *ctx, GrGLGetPro
 
     if (glVer >= GR_GL_VER(2,0)) {
         GET_PROC(CopyBufferSubData);
+        GET_PROC(GetBufferSubData);
     }
 
     if (glVer >= GR_GL_VER(2,0)) {

--- a/src/gpu/ganesh/gl/GrGLBuffer.cpp
+++ b/src/gpu/ganesh/gl/GrGLBuffer.cpp
@@ -275,6 +275,18 @@ bool GrGLBuffer::onUpdateData(const void* src, size_t offset, size_t size, bool 
     return true;
 }
 
+bool GrGLBuffer::onGetData(void* dst, size_t offset, size_t size) {
+    SkASSERT(fBufferID);
+
+    // bindbuffer handles dirty context
+    GrGLenum target = this->glGpu()->bindBuffer(fIntendedType, this);
+    if (this->glCaps().getBufferSubDataSupport()) {
+        GL_CALL(GetBufferSubData(target, offset, size, dst));
+        return true;
+    }
+    return false;
+}
+
 void GrGLBuffer::onSetLabel() {
     SkASSERT(fBufferID);
     if (!this->getLabel().empty()) {

--- a/src/gpu/ganesh/gl/GrGLBuffer.h
+++ b/src/gpu/ganesh/gl/GrGLBuffer.h
@@ -51,6 +51,7 @@ private:
     void onUnmap(MapType) override;
     bool onClearToZero() override;
     bool onUpdateData(const void* src, size_t offset, size_t size, bool preserve) override;
+    bool onGetData(void* dst, size_t offset, size_t size) override;
 
     void onSetLabel() override;
 

--- a/src/gpu/ganesh/gl/GrGLCaps.cpp
+++ b/src/gpu/ganesh/gl/GrGLCaps.cpp
@@ -100,6 +100,7 @@ GrGLCaps::GrGLCaps(const GrContextOptions& contextOptions,
     fFBFetchRequiresEnablePerSample = false;
     fSRGBWriteControl = false;
     fSkipErrorChecks = false;
+    fGetBufferSubDataSupport = false;
 
     fShaderCaps = std::make_unique<GrShaderCaps>();
 
@@ -400,6 +401,10 @@ void GrGLCaps::init(const GrContextOptions& contextOptions,
         return SkToBool(contextFlags & GR_GL_CONTEXT_FLAG_PROTECTED_CONTENT_BIT_EXT);
     }();
 
+    if (GR_IS_GR_GL(standard) || GR_IS_GR_WEBGL(standard)) {
+        fGetBufferSubDataSupport = version >= GR_GL_VER(2, 0);
+    }
+
     /**************************************************************************
     * GrShaderCaps fields
     **************************************************************************/
@@ -557,6 +562,11 @@ void GrGLCaps::init(const GrContextOptions& contextOptions,
     } else if (GR_IS_GR_WEBGL(standard)) {
         // explicitly removed https://www.khronos.org/registry/webgl/specs/2.0/#5.14
         fMapBufferFlags = kNone_MapFlags;
+        if (version >= GR_GL_VER(2, 0)) {
+            fTransferFromBufferToTextureSupport = true;
+            fTransferFromSurfaceToBufferSupport = true;
+            fTransferBufferType = TransferBufferType::kARB_PBO;
+        }
     }
 
     // Buffers have more restrictions in WebGL than GLES. For example,

--- a/src/gpu/ganesh/gl/GrGLCaps.h
+++ b/src/gpu/ganesh/gl/GrGLCaps.h
@@ -515,6 +515,8 @@ public:
 
     bool clientCanDisableMultisample() const { return fClientCanDisableMultisample; }
 
+    bool getBufferSubDataSupport() const { return fGetBufferSubDataSupport; }
+
     GrBackendFormat getBackendFormatFromCompressionType(SkTextureCompressionType) const override;
 
     skgpu::Swizzle getWriteSwizzle(const GrBackendFormat&, GrColorType) const override;
@@ -630,6 +632,7 @@ private:
     bool fSRGBWriteControl : 1;
     bool fSkipErrorChecks : 1;
     bool fClientCanDisableMultisample : 1;
+    bool fGetBufferSubDataSupport: 1;
 
     // Driver workarounds
     bool fDoManualMipmapping : 1;


### PR DESCRIPTION
Reading back pixels is blocking on WebGL. This is because skia lacks pixel transfer support with out mapping.

WebGL has PBO for async reading, however it use `glGetBufferSubData()` to read back from PIXEL_PACK_BUFFER instead of mapping

- add GetBufferSubData to GrGLInterface
- add GrGpuBuffer::getData()
- TAsyncReadResult use getData() to copy pixels to cpu plane