### PR TITLE
Add asWinding, isEmpty and addReversePath to SKPath export

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ ColdPaleLight <coldpalelight@gmail.com>
 Dawson Coleman <dawsonmcoleman@gmail.com>
 Deepak Mohan <hop2deep@gmail.com>
 Ehsan Akhgari <ehsan.akhgari@gmail.com>
+Erik Sombroek <eriksombroek@gmail.com>
 Facebook, Inc. <*fb.com>
 George Wright <george@mozilla.com>
 GiWan Go <gogil@stealien.com>

--- a/modules/pathkit/chaining.js
+++ b/modules/pathkit/chaining.js
@@ -45,6 +45,11 @@
       return this;
     };
 
+    PathKit.SkPath.prototype.reverseAddPath = function() {
+      this._reverseAddPath(arguments[0]);
+      return this;
+    };
+
     // ccw (counter clock wise) is optional and defaults to false.
     PathKit.SkPath.prototype.arc = function(x, y, radius, startAngle, endAngle, ccw) {
       this._arc(x, y, radius, startAngle, endAngle, !!ccw);
@@ -133,6 +138,17 @@
         return this;
       }
       return null;
+    };
+
+    PathKit.SkPath.prototype.asWinding = function() {
+      if (this._asWinding()) {
+        return this;
+      }
+      return null;
+    }
+
+    PathKit.SkPath.prototype.isEmpty = function() {
+      return this._isEmpty();
     };
 
     PathKit.SkPath.prototype.stroke = function(opts) {

--- a/modules/pathkit/externs.js
+++ b/modules/pathkit/externs.js
@@ -41,17 +41,20 @@ var PathKit = {
 		_addPath: function(path, scaleX, skewX, transX, skewY, scaleY, transY, pers0, pers1, pers2) {},
 		_arc: function(x, y, radius, startAngle, endAngle, ccw) {},
 		_arcTo: function(x1, y1, x2, y2, radius) {},
+		_asWinding: function() {},
 		_dash: function(on, off, phase) {},
 		_close: function() {},
 		_conicTo: function(x1, y1, x2, y2, w) {},
 		copy: function() {},
 		_cubicTo: function(cp1x, cp1y, cp2x, cp2y, x, y) {},
 		_ellipse: function(x, y, radiusX, radiusY, rotation, startAngle, endAngle, ccw) {},
+		_isEmpty: function() {},
 		_lineTo: function(x1, y1) {},
 		_moveTo: function(x1, y1) {},
 		_op: function(otherPath, op) {},
 		_quadTo: function(cpx, cpy, x, y) {},
 		_rect: function(x, y, w, h) {},
+		_reverseAddPath: function(path) {},
 		_simplify: function() {},
 		_stroke: function(opts) {},
 		_trim: function(startT, stopT, isComplement) {},
@@ -89,6 +92,7 @@ CubicMap.prototype.computePtFromT = function(t) {};
 PathKit.SkPath.prototype.addPath = function() {};
 PathKit.SkPath.prototype.arc = function(x, y, radius, startAngle, endAngle, ccw) {};
 PathKit.SkPath.prototype.arcTo = function(x1, y1, x2, y2, radius) {};
+PathKit.SkPath.prototype.asWinding = function() {};
 PathKit.SkPath.prototype.bezierCurveTo = function(cp1x, cp1y, cp2x, cp2y, x, y) {};
 PathKit.SkPath.prototype.close = function() {};
 PathKit.SkPath.prototype.closePath = function() {};
@@ -96,12 +100,14 @@ PathKit.SkPath.prototype.conicTo = function(x1, y1, x2, y2, w) {};
 PathKit.SkPath.prototype.cubicTo = function(cp1x, cp1y, cp2x, cp2y, x, y) {};
 PathKit.SkPath.prototype.dash = function(on, off, phase) {};
 PathKit.SkPath.prototype.ellipse = function(x, y, radiusX, radiusY, rotation, startAngle, endAngle, ccw) {};
+PathKit.SkPath.prototype.isEmpty = function() {};
 PathKit.SkPath.prototype.lineTo = function(x, y) {};
 PathKit.SkPath.prototype.moveTo = function(x, y) {};
 PathKit.SkPath.prototype.op = function(otherPath, op) {};
 PathKit.SkPath.prototype.quadTo = function(x1, y1, x2, y2) {};
 PathKit.SkPath.prototype.quadraticCurveTo = function(x1, y1, x2, y2) {};
 PathKit.SkPath.prototype.rect = function(x, y, w, h) {};
+PathKit.SkPath.prototype.reverseAddPath = function() {};
 PathKit.SkPath.prototype.simplify = function() {};
 PathKit.SkPath.prototype.stroke = function(opts) {};
 PathKit.SkPath.prototype.transform = function() {};

--- a/modules/pathkit/pathkit_wasm_bindings.cpp
+++ b/modules/pathkit/pathkit_wasm_bindings.cpp
@@ -204,6 +204,10 @@ void ApplyQuadTo(SkPath& p, SkScalar x1, SkScalar y1, SkScalar x2, SkScalar y2) 
     p.quadTo(x1, y1, x2, y2);
 }
 
+bool EMSCRIPTEN_KEEPALIVE IsEmpty(const SkPath& path) {
+    return path.isEmpty();
+}
+
 
 
 //========================================================================================
@@ -233,6 +237,10 @@ SkPathOrNull EMSCRIPTEN_KEEPALIVE FromSVGString(std::string str) {
 
 bool EMSCRIPTEN_KEEPALIVE ApplySimplify(SkPath& path) {
     return Simplify(path, &path);
+}
+
+bool EMSCRIPTEN_KEEPALIVE ApplyAsWinding(SkPath& path) {
+    return AsWinding(path, &path);
 }
 
 bool EMSCRIPTEN_KEEPALIVE ApplyPathOp(SkPath& pathOne, const SkPath& pathTwo, SkPathOp op) {
@@ -342,6 +350,11 @@ void ApplyAddPath(SkPath& orig, const SkPath& newPath,
                                    pers0 , pers1 , pers2);
     orig.addPath(newPath, m);
 }
+
+void ApplyReverseAddPath(SkPath& orig, const SkPath& newPath) {
+    orig.reverseAddPath(newPath);
+}
+
 
 JSString GetFillTypeString(const SkPath& path) {
     if (path.getFillType() == SkPathFillType::kWinding) {
@@ -478,6 +491,7 @@ EMSCRIPTEN_BINDINGS(skia) {
 
         // Path2D API
         .function("_addPath", &ApplyAddPath)
+        .function("_reverseAddPath", &ApplyReverseAddPath)
         // 3 additional overloads of addPath are handled in JS bindings
         .function("_arc", &ApplyAddArc)
         .function("_arcTo", &ApplyArcTo)
@@ -493,6 +507,7 @@ EMSCRIPTEN_BINDINGS(skia) {
         // "quadraticCurveTo" alias handled in JS bindings
         .function("_quadTo", &ApplyQuadTo)
         .function("_rect", &ApplyAddRect)
+        .function("_isEmpty", &IsEmpty)
 
         // Extra features
         .function("setFillType", select_overload<void(SkPathFillType)>(&SkPath::setFillType))
@@ -514,6 +529,7 @@ EMSCRIPTEN_BINDINGS(skia) {
 
         // PathOps
         .function("_simplify", &ApplySimplify)
+        .function("_asWinding", &ApplyAsWinding)
         .function("_op", &ApplyPathOp)
 
         // Exporting


### PR DESCRIPTION
Adding missing functionality to the WASM export.
I need asWinding to ensure holes are converted from evenodd to winding. 
setFillType(fillType) does not alter the winding of holes.