### PR TITLE
The patch reduces memory usage in Skia and Android.

### DIFF
--- a/src/image/SkImage_Raster.cpp
+++ b/src/image/SkImage_Raster.cpp
@@ -168,7 +168,7 @@ sk_sp<SkImage> SkImage_Raster::onMakeSubset(skgpu::graphite::Recorder*,
 
 sk_sp<SkImage> SkMakeImageFromRasterBitmapPriv(const SkBitmap& bm, SkCopyPixelsMode cpm,
                                                uint32_t idForCopy) {
-    if (kAlways_SkCopyPixelsMode == cpm || (!bm.isImmutable() && kNever_SkCopyPixelsMode != cpm)) {
+    if (kAlways_SkCopyPixelsMode == cpm || (!bm.isImmutable() && kIfMutable_SkCopyPixelsMode == cpm)) {
         SkPixmap pmap;
         if (bm.peekPixels(&pmap)) {
             return MakeRasterCopyPriv(pmap, idForCopy);


### PR DESCRIPTION
Immutable bitmap pixels should not be copied if  `kIfMutable_SkCopyPixelsMode` was passed.