### PR TITLE
Implement SkPoint class & SkPathMeasure

### DIFF
--- a/modules/pathkit/chaining.js
+++ b/modules/pathkit/chaining.js
@@ -195,6 +195,43 @@
       }
       return null;
     };
+
+    PathKit.SkPoint.prototype.set = function(x, y) {
+      this._set(x, y);
+      return this;
+    };
+
+    PathKit.SkPoint.prototype.normalize = function() {
+      this._normalize();
+      return this;
+    }
+
+    PathKit.SkPoint.prototype.scale = function(s) {
+      this._scale(s);
+      return this;
+    }
+
+    PathKit.SkPoint.prototype.offset = function(dx, dy) {
+      this._offset(dx, dy);
+      return this;
+    }
+
+    PathKit.SkPoint.prototype.negate = function() {
+      this._negate();
+      return this;
+    }
+
+    PathKit.SkPathMeasure.prototype.setPath = function(path, forceClosed) {
+      this._setPath(path, !!forceClosed);
+      return this;
+    };
+
+    PathKit.SkPathMeasure.prototype.getPosTan = function(distance, position, tangent) {
+      if(this._getPosTan(distance, position, tangent)){
+        return this;
+      }
+      return null;
+    };
   };
 
 }(Module)); // When this file is loaded in, the high level object is "Module";

--- a/modules/pathkit/externs.js
+++ b/modules/pathkit/externs.js
@@ -70,6 +70,25 @@ var PathKit = {
 		MITER: {},
 		ROUND: {},
 		BEVEL: {},
+	},
+
+	SkPoint: {
+		_set: function(x, y) {},
+		_normalize: function() {},
+		_scale: function(s) {},
+		_offset: function(dx, dy) {},
+		_negate: function() {},
+	},
+
+	SkPathMeasure:{
+		_setPath: function(path, forceClosed) {},
+		_getPosTan: function(distance, position, tangent) {},
+	},
+
+	MatrixFlag: {
+		GET_POSITION: {},
+		GET_TANGENT: {},
+		GET_POS_AND_TAN: {},
 	}
 };
 
@@ -112,3 +131,12 @@ PathKit.SkPath.prototype.simplify = function() {};
 PathKit.SkPath.prototype.stroke = function(opts) {};
 PathKit.SkPath.prototype.transform = function() {};
 PathKit.SkPath.prototype.trim = function(startT, stopT, isComplement) {};
+
+PathKit.SkPathMeasure.prototype.setPath = function() {};
+PathKit.SkPathMeasure.prototype.getPosTan = function() {};
+
+PathKit.SkPoint.prototype.set = function(x, y) {};
+PathKit.SkPoint.prototype.normalize = function() {};
+PathKit.SkPoint.prototype.scale = function(s) {};
+PathKit.SkPoint.prototype.offset = function(dx, dy) {};
+PathKit.SkPoint.prototype.negate = function() {};

--- a/modules/pathkit/pathkit_wasm_bindings.cpp
+++ b/modules/pathkit/pathkit_wasm_bindings.cpp
@@ -14,6 +14,7 @@
 #include "include/core/SkRect.h"
 #include "include/core/SkString.h"
 #include "include/core/SkStrokeRec.h"
+#include "include/core/SkPathMeasure.h"
 #include "include/effects/SkDashPathEffect.h"
 #include "include/effects/SkTrimPathEffect.h"
 #include "include/pathops/SkPathOps.h"
@@ -457,6 +458,41 @@ void ApplyTransform(SkPath& orig,
 }
 
 //========================================================================================
+// SkPoint things
+//========================================================================================
+void ApplySet(SkPoint& p, SkScalar x, SkScalar y) {
+    p.set(x, y);
+}
+
+void ApplyNormalize(SkPoint& p) {
+    p.normalize();
+}
+
+void ApplyScale(SkPoint& p, SkScalar scale) {
+    p.scale(scale);
+}
+
+void ApplyOffset(SkPoint& p, SkScalar dx, SkScalar dy) {
+    p.offset(dx, dy);
+}
+
+void ApplyNegate(SkPoint& p) {
+    p.negate();
+}
+
+//========================================================================================
+// SkPathMeasure things
+//========================================================================================
+
+void ApplySetPath(SkPathMeasure& pm, const SkPath& path, bool forceClosed) {
+    pm.setPath(&path, forceClosed);
+}
+
+bool EMSCRIPTEN_KEEPALIVE GetPosTan(SkPathMeasure& pm, SkScalar distance, SkPoint *position, SkPoint *tangent) {
+    return pm.getPosTan(distance, position, tangent);
+}
+
+//========================================================================================
 // Testing things
 //========================================================================================
 
@@ -633,9 +669,25 @@ EMSCRIPTEN_BINDINGS(skia) {
         .element(&SimpleMatrix::pers1)
         .element(&SimpleMatrix::pers2);
 
-    value_array<SkPoint>("SkPoint")
-        .element(&SkPoint::fX)
-        .element(&SkPoint::fY);
+    class_<SkPoint>("SkPoint")
+        .constructor<>()
+        .function("_set", &ApplySet)
+        .function("_normalize", &ApplyNormalize)
+        .function("_scale", &ApplyScale)
+        .function("_offset", &ApplyOffset)
+        .function("_negate", &ApplyNegate)
+
+        .function("length", &SkPoint::length)
+        .function("dot", &SkPoint::dot)
+        .function("cross", &SkPoint::cross)
+        .property("x", &SkPoint::fX)
+        .property("y", &SkPoint::fY)
+
+        // Static methods
+        .class_function("Distance", &SkPoint::Distance)
+        .class_function("DotProduct", &SkPoint::DotProduct)
+        .class_function("CrossProduct", &SkPoint::CrossProduct);
+
 
     // Not intended for external clients to call directly.
     // See helper.js for the client-facing implementation.
@@ -645,6 +697,24 @@ EMSCRIPTEN_BINDINGS(skia) {
         .function("computeYFromX", &SkCubicMap::computeYFromX)
         .function("computePtFromT", &SkCubicMap::computeFromT);
 
+    class_<SkPathMeasure>("SkPathMeasure")
+        .constructor<>()
+        .constructor<const SkPath&, bool>()
+        .constructor<const SkPath&, bool, SkScalar>()
+
+        .function("_setPath", &ApplySetPath)
+        .function("_getPosTan", &GetPosTan, allow_raw_pointer<arg<3>>(), allow_raw_pointer<arg<4>>())
+
+        .function("getLength", &SkPathMeasure::getLength)
+        .function("getSegment", &SkPathMeasure::getSegment, allow_raw_pointer<arg<3>>())
+        .function("isClosed", &SkPathMeasure::isClosed)
+        .function("nextContour", &SkPathMeasure::nextContour)
+        ;
+
+    enum_<SkPathMeasure::MatrixFlags>("MatrixFlags")
+        .value("GET_POSITION", SkPathMeasure::kGetPosition_MatrixFlag)
+        .value("GET_TANGENT", SkPathMeasure::kGetTangent_MatrixFlag)
+        .value("GET_POS_AND_TAN", SkPathMeasure::kGetPosAndTan_MatrixFlag);
 
     // Test Utils
     function("SkBits2FloatUnsigned", &SkBits2FloatUnsigned);


### PR DESCRIPTION
Adding class implementation for SkPoint and SkPathMeasure.

I tried getting the SkPathMeasure to work with the following embind:
```
    value_array<SkPoint>("SkPoint")
        .element(&SkPoint::fX)
        .element(&SkPoint::fY);
```

But I kept on getting the error `UnboundTypeError, Cannot call SkPathMeasure._getPosTan due to unbound types: 0x2c03`
It seems when using a value_array as a raw pointer there are difficulties with properly binding the C++ types to their JavaScript equivalents.

I would also like to implement `SkPathMeasure::getMatrix` but this would also require binding the SkMatrix with `class_<SkMatrix>`, and before I do that I wanted to check in with you If I'm missing something or if this is the way to go.