### PR TITLE
fix context.size==0 index out of bound error in paragraph extendedVisit

### DIFF
--- a/modules/skparagraph/src/ParagraphImpl.cpp
+++ b/modules/skparagraph/src/ParagraphImpl.cpp
@@ -1420,12 +1420,16 @@ void ParagraphImpl::extendedVisit(const ExtendedVisitor& visitor) {
                     STArray<128, uint32_t> clusterStorage;
                     const uint32_t* clusterPtr = run->clusterIndexes().data();
                     if (run->fClusterStart > 0) {
-                        clusterStorage.reset(context.size);
-                        for (size_t i = 0; i < context.size; ++i) {
-                          clusterStorage[i] =
-                              run->fClusterStart + run->fClusterIndexes[i];
+                        if (context.size > 0) {
+                            clusterStorage.reset(context.size);
+                            for (size_t i = 0; i < context.size; ++i) {
+                                clusterStorage[i] =
+                                        run->fClusterStart + run->fClusterIndexes[i];
+                            }
+                            clusterPtr = &clusterStorage[0];
+                        } else {
+                            clusterPtr = nullptr;
                         }
-                        clusterPtr = &clusterStorage[0];
                     }
                     const Paragraph::ExtendedVisitorInfo info = {
                         run->font(),


### PR DESCRIPTION
ref: https://issues.skia.org/issues/314826646

reproduce example

```cpp
#include <include/core/SkRefCnt.h>
#include "include/core/SkCanvas.h"
#include "include/core/SkSurface.h"
#include "include/core/SkPixmap.h"
#include "include/core/SkStream.h"
#include "include/effects/SkBlurMaskFilter.h"
#include <include/core/SkBitmap.h>
#include "include/ports/SkTypeface_win.h"
#include "modules/skparagraph/include/ParagraphBuilder.h"
#include <filesystem>
#include <fstream>
#include <vector>
#include <modules/skunicode/include/SkUnicode_icu.h>

int main() {
    SkBitmap bitmap;
    bitmap.allocPixels(SkImageInfo::MakeN32Premul(800, 600));
    SkCanvas canvas(bitmap);

    auto fFM = SkFontMgr_New_DirectWrite();

    auto paraFonts = sk_make_sp<skia::textlayout::FontCollection>();
    paraFonts->setDefaultFontManager(fFM);

    auto paraUnicode = SkUnicodes::ICU::Make();

    auto paraStyle = skia::textlayout::ParagraphStyle();

    auto builder = skia::textlayout::ParagraphBuilder::make(paraStyle, paraFonts, paraUnicode);

    skia::textlayout::TextStyle textStyle;
    textStyle.setFontFamilies({SkString("Source Han Sans VF")});

    std::vector<std::string> locales = {"ko", "ja", "zh-Hant", "zh-Hans"};
    for (const auto &locale: locales) {
        textStyle.setLocale(SkString(locale.c_str()));
        builder->pushStyle(textStyle);
        std::string payload("曜\n");
        builder->addText(payload.c_str(), payload.size());
    }

    auto paragraph = builder->Build();
    paragraph->layout(1600);

    paragraph->extendedVisit([&](int lineNumber, const skia::textlayout::Paragraph::ExtendedVisitorInfo *info) {
        // crash
    });

    return 0;
}
```