### PR TITLE
Fix SkOrderedFontMgr::onMatchFamily

### DIFF
--- a/src/utils/SkOrderedFontMgr.cpp
+++ b/src/utils/SkOrderedFontMgr.cpp
@@ -55,7 +55,8 @@ sk_sp<SkFontStyleSet> SkOrderedFontMgr::onCreateStyleSet(int index) const {
 
 sk_sp<SkFontStyleSet> SkOrderedFontMgr::onMatchFamily(const char familyName[]) const {
     for (const auto& fm : fList) {
-        if (auto fs = fm->matchFamily(familyName)) {
+        const auto fs = fm->matchFamily(familyName);
+        if (fs->count() > 0){
             return fs;
         }
     }


### PR DESCRIPTION
SkOrderedFontMgr's `matchFamily` currently has [a bug](https://issues.skia.org/issues/382016481) where it will only look in the first FontMgr in its list when searching for fonts. The problem is that its search loop is expecting a `null` response to signal "no matches", but the actual behavior of FontMgr is to never return null. Instead it will return a zero-length SkFontStyleSet. 

This PR adds a `count() > 0` check to the return value rather than just checking whether it is non-null.