### PR TITLE
[SkPathOpsTSect] Tiny logic simplification

### DIFF
--- a/src/pathops/SkPathOpsTSect.cpp
+++ b/src/pathops/SkPathOpsTSect.cpp
@@ -1826,8 +1826,8 @@ void SkTSect::BinarySearch(SkTSect* sect1,
         }
         SkTSpan* largest2 = sect2->boundsMax();
         // split it
-        if (!largest2 || (largest1 && (largest1->fBoundsMax > largest2->fBoundsMax
-                || (!largest1->fCollapsed && largest2->fCollapsed)))) {
+        if (!largest2 || largest1->fBoundsMax > largest2->fBoundsMax
+                || (!largest1->fCollapsed && largest2->fCollapsed)) {
             if (sect2->fHung) {
                 return;
             }


### PR DESCRIPTION
l.1829 tests whether `largest1` is true - but `largest1` is *guaranteed* to be true here because we've already handled the false case above with either an early return or a break out of the loop:

https://github.com/google/skia/blob/eb9ff8e42760a250e456eb72aedc01bcb1357cd5/src/pathops/SkPathOpsTSect.cpp#L1821-L1829

I know it's a tiny simplification but this is a tricky bit of code and anything which makes it easier is a bonus.