### PR TITLE
Add support for configuring font edging/hinting/subpixel to SkParagraph

### DIFF
--- a/modules/skparagraph/include/TextStyle.h
+++ b/modules/skparagraph/include/TextStyle.h
@@ -287,6 +287,15 @@ public:
     bool isPlaceholder() const { return fIsPlaceholder; }
     void setPlaceholder() { fIsPlaceholder = true; }
 
+    void setFontEdging(SkFont::Edging edging) { fEdging = edging; }
+    SkFont::Edging getFontEdging() const { return fEdging; }
+
+    void setSubpixel(bool subpixel) { fSubpixel = subpixel; }
+    bool getSubpixel() const { return fSubpixel; }
+
+    void setFontHinting(SkFontHinting hinting) { fHinting = hinting; }
+    SkFontHinting getFontHinting() const { return fHinting; }
+
 private:
     static const std::vector<SkString>* kDefaultFontFamilies;
 
@@ -305,6 +314,9 @@ private:
     std::vector<SkString> fFontFamilies = *kDefaultFontFamilies;
 
     SkScalar fFontSize = 14.0;
+    SkFont::Edging fEdging = SkFont::Edging::kAntiAlias;
+    bool fSubpixel = true;
+    SkFontHinting fHinting = SkFontHinting::kSlight;
     SkScalar fHeight = 1.0;
     bool fHeightOverride = false;
     SkScalar fBaselineShift = 0.0f;

--- a/modules/skparagraph/src/OneLineShaper.cpp
+++ b/modules/skparagraph/src/OneLineShaper.cpp
@@ -585,6 +585,10 @@ bool OneLineShaper::iterateThroughShapingRegions(const ShapeVisitor& shape) {
         sk_sp<SkTypeface> typeface = typefaces.empty() ? nullptr : typefaces.front();
         SkFont font(typeface, placeholder.fTextStyle.getFontSize());
 
+        font.setEdging(placeholder.fTextStyle.getFontEdging());
+        font.setHinting(placeholder.fTextStyle.getFontHinting());
+        font.setSubpixel(placeholder.fTextStyle.getSubpixel());
+
         // "Shape" the placeholder
         uint8_t bidiLevel = (bidiIndex < fParagraph->fBidiRegions.size())
             ? fParagraph->fBidiRegions[bidiIndex].level

--- a/modules/skparagraph/src/OneLineShaper.cpp
+++ b/modules/skparagraph/src/OneLineShaper.cpp
@@ -649,9 +649,9 @@ bool OneLineShaper::shape() {
 
                 // Create one more font to try
                 SkFont font(std::move(typeface), block.fStyle.getFontSize());
-                font.setEdging(SkFont::Edging::kAntiAlias);
-                font.setHinting(SkFontHinting::kSlight);
-                font.setSubpixel(true);
+                font.setEdging(block.fStyle.getFontEdging());
+                font.setHinting(block.fStyle.getFontHinting());
+                font.setSubpixel(block.fStyle.getSubpixel());
 
                 // Apply fake bold and/or italic settings to the font if the
                 // typeface's attributes do not match the intended font style.

--- a/modules/skparagraph/src/TextLine.cpp
+++ b/modules/skparagraph/src/TextLine.cpp
@@ -684,9 +684,9 @@ std::unique_ptr<Run> TextLine::shapeEllipsis(const SkString& ellipsis, const Clu
     auto shaped = [&](sk_sp<SkTypeface> typeface, sk_sp<SkFontMgr> fallback) -> std::unique_ptr<Run> {
         ShapeHandler handler(run.heightMultiplier(), run.useHalfLeading(), run.baselineShift(), ellipsis);
         SkFont font(std::move(typeface), textStyle.getFontSize());
-        font.setEdging(SkFont::Edging::kAntiAlias);
-        font.setHinting(SkFontHinting::kSlight);
-        font.setSubpixel(true);
+        font.setEdging(textStyle.getFontEdging());
+        font.setHinting(textStyle.getFontHinting());
+        font.setSubpixel(textStyle.getSubpixel());
 
         std::unique_ptr<SkShaper> shaper = SkShapers::HB::ShapeDontWrapOrReorder(
                 fOwner->getUnicode(), fallback ? fallback : SkFontMgr::RefEmpty());

--- a/modules/skparagraph/src/TextStyle.cpp
+++ b/modules/skparagraph/src/TextStyle.cpp
@@ -166,9 +166,9 @@ bool TextStyle::matchOneAttribute(StyleType styleType, const TextStyle& other) c
 
 void TextStyle::getFontMetrics(SkFontMetrics* metrics) const {
     SkFont font(fTypeface, fFontSize);
-    font.setEdging(SkFont::Edging::kAntiAlias);
-    font.setSubpixel(true);
-    font.setHinting(SkFontHinting::kSlight);
+    font.setEdging(fEdging);
+    font.setSubpixel(fSubpixel);
+    font.setHinting(fHinting);
     font.getMetrics(metrics);
     if (fHeightOverride) {
         auto multiplier = fHeight * fFontSize;


### PR DESCRIPTION
Hello,

This PR is adding support for specifying Font edging / hinting / subpixel to `SkParagraph`/`TextStyle`.

Previously, the values were hardcoded to:

```c
font.setEdging(SkFont::Edging::kAntiAlias);
font.setHinting(SkFontHinting::kSlight);
font.setSubpixel(true);
```

This PR allows to configure these properties from `TextStyle` directly.
