### PR TITLE
[Fontations] Match FreeType backend for autohinting selection on Android

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,6 +30,7 @@ Brian Salomon <briansalomon@gmail.com>
 Callum Moffat <smartercallum@gmail.com>
 Cary Clark <cclark2@gmail.com>
 Casey Banner <kcbanner@gmail.com>
+Chad Brokaw <cbrokaw@gmail.com>
 ChengYang <chengyangyang-hf@loongson.cn>
 Christian Plesner Hansen <plesner@t.undra.org>
 ColdPaleLight <coldpalelight@gmail.com>

--- a/src/ports/SkTypeface_fontations.cpp
+++ b/src/ports/SkTypeface_fontations.cpp
@@ -363,13 +363,13 @@ public:
         fontations_ffi::AutoHintingControl autoHintingControl =
                 forceAutoHinting
                         ? fontations_ffi::AutoHintingControl::ForceForGlyfAndCff
-                        : fontations_ffi::AutoHintingControl::AutoAsFallback;
+                        : fontations_ffi::AutoHintingControl::Fallback;
 
 #ifdef SK_BUILD_FOR_ANDROID_FRAMEWORK
         // On Android, match the FreeType backend and disable autohinting completely
         // unless the force flag is set.
         if (!forceAutoHinting)
-            autoHintingControl = fontations_ffi::AutoHintingControl::ForceInterpreter;
+            autoHintingControl = fontations_ffi::AutoHintingControl::ForceOff;
 #endif
 
         // Hinting-reliant fonts exist that display incorrect contours when not executing their
@@ -399,9 +399,9 @@ public:
                         if (autoHintingControl !=
                             fontations_ffi::AutoHintingControl::ForceForGlyfAndCff &&
                             autoHintingControl !=
-                            fontations_ffi::AutoHintingControl::ForceInterpreter) {
+                            fontations_ffi::AutoHintingControl::ForceOff) {
                             autoHintingControl =
-                                    fontations_ffi::AutoHintingControl::PreferAutoOverHintsForGlyf;
+                                    fontations_ffi::AutoHintingControl::ForceForGlyf;
                         }
                         fHintingInstance = fontations_ffi::make_hinting_instance(
                                 fOutlines,

--- a/src/ports/SkTypeface_fontations.cpp
+++ b/src/ports/SkTypeface_fontations.cpp
@@ -363,7 +363,7 @@ public:
         // See below for the exception for SkFontHinting::kSlight.
         bool forceAutoHinting = SkToBool(fRec.fFlags & kForceAutohinting_Flag);
         AutoHinting autoHintingControl = forceAutoHinting ? AutoHinting::ForceForGlyfAndCff
-                : AutoHinting::Fallback;
+                                                          : AutoHinting::Fallback;
 
 #ifdef SK_BUILD_FOR_ANDROID_FRAMEWORK
         // On Android, match the FreeType backend and disable autohinting completely

--- a/src/ports/fontations/src/ffi.rs
+++ b/src/ports/fontations/src/ffi.rs
@@ -165,6 +165,7 @@ pub mod ffi {
     pub enum AutoHintingControl {
         PreferAutoOverHintsForGlyf,
         ForceForGlyfAndCff,
+        ForceInterpreter,
         AutoAsFallback,
     }
 

--- a/src/ports/fontations/src/ffi.rs
+++ b/src/ports/fontations/src/ffi.rs
@@ -163,10 +163,10 @@ pub mod ffi {
     }
 
     pub enum AutoHintingControl {
-        PreferAutoOverHintsForGlyf,
+        ForceForGlyf,
         ForceForGlyfAndCff,
-        ForceInterpreter,
-        AutoAsFallback,
+        ForceOff,
+        Fallback,
     }
 
     pub enum OutlineFormat {

--- a/src/ports/fontations/src/hinting.rs
+++ b/src/ports/fontations/src/hinting.rs
@@ -91,6 +91,7 @@ pub unsafe fn make_hinting_instance<'a>(
                     );
                     Engine::Auto(glyph_styles.cloned())
                 }
+                (AutoHintingControl::ForceInterpreter, _) => Engine::Interpreter,
                 _ => Engine::AutoFallback,
             };
 

--- a/src/ports/fontations/src/hinting.rs
+++ b/src/ports/fontations/src/hinting.rs
@@ -80,7 +80,7 @@ pub unsafe fn make_hinting_instance<'a>(
             // So Engine::AutoFallback does not engage autohinting for CFF.
             let engine_type = match (autohinting_control, outlines.format()) {
                 (
-                    AutoHintingControl::PreferAutoOverHintsForGlyf,
+                    AutoHintingControl::ForceForGlyf,
                     Some(OutlineGlyphFormat::Glyf),
                 )
                 | (AutoHintingControl::ForceForGlyfAndCff, _) => {
@@ -91,7 +91,7 @@ pub unsafe fn make_hinting_instance<'a>(
                     );
                     Engine::Auto(glyph_styles.cloned())
                 }
-                (AutoHintingControl::ForceInterpreter, _) => Engine::Interpreter,
+                (AutoHintingControl::ForceOff, _) => Engine::Interpreter,
                 _ => Engine::AutoFallback,
             };
 


### PR DESCRIPTION
On Android, the FreeType backend only enables autohinting when the force flag is set and prevents fallback otherwise regardless of the requested hinting mode or presence of native hints in the font. This changes the Fontations backend to match that behavior.