### PR TITLE
use ParagraphStyle's `fHintingIsOn` flag when typesetting

### DIFF
--- a/modules/skparagraph/src/OneLineShaper.cpp
+++ b/modules/skparagraph/src/OneLineShaper.cpp
@@ -654,7 +654,9 @@ bool OneLineShaper::shape() {
                 // Create one more font to try
                 SkFont font(std::move(typeface), block.fStyle.getFontSize());
                 font.setEdging(block.fStyle.getFontEdging());
-                font.setHinting(block.fStyle.getFontHinting());
+                font.setHinting(
+                  fParagraph->paragraphStyle().hintingIsOn() ? block.fStyle.getFontHinting() : SkFontHinting:kNone
+                );
                 font.setSubpixel(block.fStyle.getSubpixel());
 
                 // Apply fake bold and/or italic settings to the font if the


### PR DESCRIPTION
The `ParagraphStyle` struct has as [turnHintingOff()](https://github.com/google/skia/blob/ebb6051e8bb1d31c3e9860081c154e49a564c6ef/modules/skparagraph/include/ParagraphStyle.h#L122) setter which toggles its `fHintingIsOn` flag, but this flag is never read when the paragraph is typeset. As a result, hinting is always enabled regardless of the `ParagraphStyle`’s settings.

This PR adds a check for hinting having been disabled at the `ParagraphStyle` level and only defers to the `Block`'s hinting setting if it is enabled.

Note: it's not entirely clear to me that this is the proper (or only) location for this flag to be honored, but having the ability to disable hinting at the `ParagraphStyle` level is an important feature (since direct access to the Font objects used is unavailable when typesetting paragraphs rather than TextBlobs). It's also a feature that the existing API suggests exists, while currently it has no effect. 