### PR TITLE
Add ParagraphStyle setting to choose whether missing font weight/slant should be faked

### DIFF
--- a/modules/skparagraph/include/ParagraphStyle.h
+++ b/modules/skparagraph/include/ParagraphStyle.h
@@ -84,7 +84,9 @@ struct ParagraphStyle {
                this->fEllipsisUtf16 == rhs.fEllipsisUtf16 &&
                this->fTextDirection == rhs.fTextDirection && this->fTextAlign == rhs.fTextAlign &&
                this->fDefaultTextStyle == rhs.fDefaultTextStyle &&
-               this->fReplaceTabCharacters == rhs.fReplaceTabCharacters;
+               this->fReplaceTabCharacters == rhs.fReplaceTabCharacters &&
+               this->fFakeMissingFontStyles == rhs.fFakeMissingFontStyles;
+
     }
 
     const StrutStyle& getStrutStyle() const { return fStrutStyle; }
@@ -121,6 +123,9 @@ struct ParagraphStyle {
     bool hintingIsOn() const { return fHintingIsOn; }
     void turnHintingOff() { fHintingIsOn = false; }
 
+    bool fakeMissingFontStyles() const { return fFakeMissingFontStyles; }
+    void setFakeMissingFontStyles(bool value) { fFakeMissingFontStyles = value; }
+
     bool getReplaceTabCharacters() const { return fReplaceTabCharacters; }
     void setReplaceTabCharacters(bool value) { fReplaceTabCharacters = value; }
 
@@ -139,6 +144,7 @@ private:
     TextHeightBehavior fTextHeightBehavior;
     bool fHintingIsOn;
     bool fReplaceTabCharacters;
+    bool fFakeMissingFontStyles;
     bool fApplyRoundingHack = true;
 };
 }  // namespace textlayout

--- a/modules/skparagraph/src/OneLineShaper.cpp
+++ b/modules/skparagraph/src/OneLineShaper.cpp
@@ -657,17 +657,19 @@ bool OneLineShaper::shape() {
                 font.setHinting(block.fStyle.getFontHinting());
                 font.setSubpixel(block.fStyle.getSubpixel());
 
-                // Apply fake bold and/or italic settings to the font if the
-                // typeface's attributes do not match the intended font style.
-                int wantedWeight = block.fStyle.getFontStyle().weight();
-                bool fakeBold =
-                    wantedWeight >= SkFontStyle::kSemiBold_Weight &&
-                    wantedWeight - font.getTypeface()->fontStyle().weight() >= 200;
-                bool fakeItalic =
-                    block.fStyle.getFontStyle().slant() == SkFontStyle::kItalic_Slant &&
-                    font.getTypeface()->fontStyle().slant() != SkFontStyle::kItalic_Slant;
-                font.setEmbolden(fakeBold);
-                font.setSkewX(fakeItalic ? -SK_Scalar1 / 4 : 0);
+                if (fParagraph->paragraphStyle().fakeMissingFontStyles()) {
+                  // Apply fake bold and/or italic settings to the font if the
+                  // typeface's attributes do not match the intended font style.
+                  int wantedWeight = block.fStyle.getFontStyle().weight();
+                  bool fakeBold =
+                      wantedWeight >= SkFontStyle::kSemiBold_Weight &&
+                      wantedWeight - font.getTypeface()->fontStyle().weight() >= 200;
+                  bool fakeItalic =
+                      block.fStyle.getFontStyle().slant() == SkFontStyle::kItalic_Slant &&
+                      font.getTypeface()->fontStyle().slant() != SkFontStyle::kItalic_Slant;
+                  font.setEmbolden(fakeBold);
+                  font.setSkewX(fakeItalic ? -SK_Scalar1 / 4 : 0);
+                }
 
                 // Walk through all the currently unresolved blocks
                 // (ignoring those that appear later)

--- a/modules/skparagraph/src/ParagraphStyle.cpp
+++ b/modules/skparagraph/src/ParagraphStyle.cpp
@@ -27,6 +27,7 @@ ParagraphStyle::ParagraphStyle() {
     fTextHeightBehavior = TextHeightBehavior::kAll;
     fHintingIsOn = true;
     fReplaceTabCharacters = false;
+    fFakeMissingFontStyles = true;
 }
 
 TextAlign ParagraphStyle::effective_align() const {


### PR DESCRIPTION
### Motivation
`OneLineShaper` currently compares each typeface to the requested `FontStyle` and detects cases where there is a mismatch in terms of italic/upright-ness or bold-ness (with a threshold of semibold or heavier counting as 'bold'). If it detects a mismatch it will apply a shear transform to create a fake italic or outdent the strokes to create a fake bold.

While there are cases where this automated behavior is desirable, there are also times where it is preferable to use an unmodified typeface (albeit with a different style than requested) rather than a synthetically generated one.

### Changes
This PR adds a boolean property to `ParagraphStyle` called `fFakeMissingFontStyles` which defaults to `true` (so as not to change the current default behavior) but can be toggled to `false` by calling the `setFakeMissingFontStyles()` accessor. `OneLineShaper` has been updated to apply its faking routines only if the flag is enabled.